### PR TITLE
fix: skip empty label resource blocks

### DIFF
--- a/internal/terraform/labels.go
+++ b/internal/terraform/labels.go
@@ -23,17 +23,16 @@ func WriteGroupLabelVariable(groups []*gl.Group, groupLabels gitlab.GroupLabels,
 		}
 		labels := groupLabels[g.ID]
 		if len(labels) == 0 {
-			fmt.Fprintf(&b, "    \"%s\" = {}\n", g.FullPath)
-		} else {
-			fmt.Fprintf(&b, "    \"%s\" = {\n", g.FullPath)
-			for _, l := range labels {
-				fmt.Fprintf(&b, "      \"%s\" = {\n", l.Name)
-				fmt.Fprintf(&b, "        color       = \"%s\"\n", l.Color)
-				fmt.Fprintf(&b, "        description = \"%s\"\n", l.Description)
-				b.WriteString("      }\n")
-			}
-			b.WriteString("    }\n")
+			continue
 		}
+		fmt.Fprintf(&b, "    \"%s\" = {\n", g.FullPath)
+		for _, l := range labels {
+			fmt.Fprintf(&b, "      \"%s\" = {\n", l.Name)
+			fmt.Fprintf(&b, "        color       = \"%s\"\n", l.Color)
+			fmt.Fprintf(&b, "        description = \"%s\"\n", l.Description)
+			b.WriteString("      }\n")
+		}
+		b.WriteString("    }\n")
 	}
 
 	b.WriteString("  }\n")
@@ -69,17 +68,16 @@ func WriteProjectLabelVariable(projects []*gl.Project, projectLabels gitlab.Proj
 		path := projectFullPath(p)
 		labels := projectLabels[p.ID]
 		if len(labels) == 0 {
-			fmt.Fprintf(&b, "    \"%s\" = {}\n", path)
-		} else {
-			fmt.Fprintf(&b, "    \"%s\" = {\n", path)
-			for _, l := range labels {
-				fmt.Fprintf(&b, "      \"%s\" = {\n", l.Name)
-				fmt.Fprintf(&b, "        color       = \"%s\"\n", l.Color)
-				fmt.Fprintf(&b, "        description = \"%s\"\n", l.Description)
-				b.WriteString("      }\n")
-			}
-			b.WriteString("    }\n")
+			continue
 		}
+		fmt.Fprintf(&b, "    \"%s\" = {\n", path)
+		for _, l := range labels {
+			fmt.Fprintf(&b, "      \"%s\" = {\n", l.Name)
+			fmt.Fprintf(&b, "        color       = \"%s\"\n", l.Color)
+			fmt.Fprintf(&b, "        description = \"%s\"\n", l.Description)
+			b.WriteString("      }\n")
+		}
+		b.WriteString("    }\n")
 	}
 
 	b.WriteString("  }\n")

--- a/internal/terraform/testdata/group_label_variable.tf
+++ b/internal/terraform/testdata/group_label_variable.tf
@@ -11,6 +11,5 @@ variable "gitlab_group_label" {
         description = "Feature requests"
       }
     }
-    "my-group/sub-group" = {}
   }
 }

--- a/internal/terraform/testdata/project_label_variable.tf
+++ b/internal/terraform/testdata/project_label_variable.tf
@@ -7,6 +7,5 @@ variable "gitlab_project_label" {
         description = "Urgent issues"
       }
     }
-    "my-group/other-project" = {}
   }
 }

--- a/internal/terraform/writer.go
+++ b/internal/terraform/writer.go
@@ -124,7 +124,7 @@ func WriteAll(resources *gitlab.Resources, dir string, mainGroup string, skipSet
 						return err
 					}
 				}
-				if !skipSet.Has("labels") {
+				if !skipSet.Has("labels") && len(resources.GroupLabels[group.ID]) > 0 {
 					if err := WriteGroupLabelResource(group, w); err != nil {
 						return err
 					}
@@ -147,7 +147,7 @@ func WriteAll(resources *gitlab.Resources, dir string, mainGroup string, skipSet
 							return err
 						}
 					}
-					if !skipSet.Has("labels") {
+					if !skipSet.Has("labels") && len(resources.ProjectLabels[p.ID]) > 0 {
 						if err := WriteProjectLabelResource(p, w); err != nil {
 							return err
 						}


### PR DESCRIPTION
## Summary
- Groups and projects with zero labels no longer generate `resource "gitlab_group_label"` / `resource "gitlab_project_label"` blocks in per-namespace files
- Variable files (`group_labels.tf`, `project_labels.tf`) no longer include empty `"path" = {}` entries for groups/projects without labels

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] Manual: run scan against a GitLab instance — only groups/projects with actual labels should have resource blocks