### PR TITLE
feat: add support for pipeline schedules and schedule variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ terraform/
 ├── project_membership.tf   # generated: variable with project → shared groups
 ├── group_labels.tf         # generated: variable with group → labels
 ├── project_labels.tf       # generated: variable with project → labels
+├── pipeline_schedules.tf   # generated: variable with project → pipeline schedules
 └── ...
 ```
 
@@ -100,6 +101,8 @@ terraform/
 - ✅ GitLab Project Share Groups ([`gitlab_project_share_group`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_share_group))
 - ✅ GitLab Group Labels ([`gitlab_group_label`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/group_label))
 - ✅ GitLab Project Labels ([`gitlab_project_label`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_label))
+- ✅ GitLab Pipeline Schedules ([`gitlab_pipeline_schedule`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/pipeline_schedule))
+- ✅ GitLab Pipeline Schedule Variables ([`gitlab_pipeline_schedule_variable`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/pipeline_schedule_variable))
 - 🚧 More resources coming soon
 
 ## Contributing

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/xMoelletschi/terraform-gitlab-drift/internal/skip"
 	gl "gitlab.com/gitlab-org/api/client-go"
@@ -38,11 +39,13 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 	if err != nil {
 		return nil, fmt.Errorf("listing groups: %w", err)
 	}
+	slog.Info("fetched groups", "count", len(groups))
 
 	projects, err := c.ListProjects(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing projects: %w", err)
 	}
+	slog.Info("fetched projects", "count", len(projects))
 
 	var groupMembers GroupMembers
 	if !skipSet.Has("memberships") {
@@ -50,6 +53,7 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		if err != nil {
 			return nil, fmt.Errorf("listing group members: %w", err)
 		}
+		slog.Info("fetched group members", "count", len(groupMembers))
 	}
 
 	var groupLabels GroupLabels
@@ -59,10 +63,13 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		if err != nil {
 			return nil, fmt.Errorf("listing group labels: %w", err)
 		}
+		slog.Info("fetched group labels", "count", len(groupLabels))
+
 		projectLabels, err = c.ListProjectLabels(ctx, projects)
 		if err != nil {
 			return nil, fmt.Errorf("listing project labels: %w", err)
 		}
+		slog.Info("fetched project labels", "count", len(projectLabels))
 	}
 
 	return &Resources{

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -15,11 +15,12 @@ type Client struct {
 }
 
 type Resources struct {
-	Groups        []*gl.Group
-	Projects      []*gl.Project
-	GroupMembers  GroupMembers
-	GroupLabels   GroupLabels
-	ProjectLabels ProjectLabels
+	Groups            []*gl.Group
+	Projects          []*gl.Project
+	GroupMembers      GroupMembers
+	GroupLabels       GroupLabels
+	ProjectLabels     ProjectLabels
+	PipelineSchedules PipelineSchedules
 }
 
 func NewClientFromAPI(api *gl.Client, group string) *Client {
@@ -72,11 +73,21 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		slog.Info("fetched project labels", "count", len(projectLabels))
 	}
 
+	var pipelineSchedules PipelineSchedules
+	if !skipSet.Has("schedules") {
+		pipelineSchedules, err = c.ListPipelineSchedules(ctx, projects)
+		if err != nil {
+			return nil, fmt.Errorf("listing pipeline schedules: %w", err)
+		}
+		slog.Info("fetched pipeline schedules", "count", len(pipelineSchedules))
+	}
+
 	return &Resources{
-		Groups:        groups,
-		Projects:      projects,
-		GroupMembers:  groupMembers,
-		GroupLabels:   groupLabels,
-		ProjectLabels: projectLabels,
+		Groups:            groups,
+		Projects:          projects,
+		GroupMembers:      groupMembers,
+		GroupLabels:       groupLabels,
+		ProjectLabels:     projectLabels,
+		PipelineSchedules: pipelineSchedules,
 	}, nil
 }

--- a/internal/gitlab/group_members.go
+++ b/internal/gitlab/group_members.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	gl "gitlab.com/gitlab-org/api/client-go"
 )
@@ -17,6 +18,7 @@ func (c *Client) ListGroupMembers(ctx context.Context, groups []*gl.Group) (Grou
 		if g == nil {
 			continue
 		}
+		slog.Debug("fetching group members", "group", g.FullPath)
 		opts := &gl.ListGroupMembersOptions{
 			ListOptions: gl.ListOptions{
 				Page:    1,

--- a/internal/gitlab/groups.go
+++ b/internal/gitlab/groups.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	gl "gitlab.com/gitlab-org/api/client-go"
 )
@@ -11,6 +12,7 @@ func (c *Client) ListGroups(ctx context.Context) ([]*gl.Group, error) {
 	var allGroups []*gl.Group
 
 	if c.group != "" {
+		slog.Debug("fetching groups", "group", c.group)
 		// First, fetch the main group itself
 		mainGroup, _, err := c.api.Groups.GetGroup(c.group, nil, gl.WithContext(ctx))
 		if err != nil {

--- a/internal/gitlab/labels.go
+++ b/internal/gitlab/labels.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	gl "gitlab.com/gitlab-org/api/client-go"
 )
@@ -21,6 +22,7 @@ func (c *Client) ListGroupLabels(ctx context.Context, groups []*gl.Group) (Group
 		if g == nil {
 			continue
 		}
+		slog.Debug("fetching group labels", "group", g.FullPath)
 		opts := &gl.ListGroupLabelsOptions{
 			ListOptions: gl.ListOptions{
 				Page:    1,
@@ -62,6 +64,7 @@ func (c *Client) ListProjectLabels(ctx context.Context, projects []*gl.Project) 
 		if p == nil {
 			continue
 		}
+		slog.Debug("fetching project labels", "project", p.PathWithNamespace)
 		opts := &gl.ListLabelsOptions{
 			ListOptions: gl.ListOptions{
 				Page:    1,

--- a/internal/gitlab/pipeline_schedules.go
+++ b/internal/gitlab/pipeline_schedules.go
@@ -1,0 +1,56 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+type PipelineSchedules = map[int64][]*gl.PipelineSchedule
+
+func (c *Client) ListPipelineSchedules(ctx context.Context, projects []*gl.Project) (PipelineSchedules, error) {
+	result := make(PipelineSchedules, len(projects))
+
+	for _, p := range projects {
+		if p == nil {
+			continue
+		}
+		slog.Debug("fetching pipeline schedules", "project", p.PathWithNamespace)
+		opts := &gl.ListPipelineSchedulesOptions{
+			ListOptions: gl.ListOptions{
+				Page:    1,
+				PerPage: 100,
+			},
+		}
+		var schedules []*gl.PipelineSchedule
+		for {
+			page, resp, err := c.api.PipelineSchedules.ListPipelineSchedules(p.ID, opts, gl.WithContext(ctx))
+			if err != nil {
+				return nil, fmt.Errorf("listing pipeline schedules for project %d: %w", p.ID, err)
+			}
+			schedules = append(schedules, page...)
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+
+		// Fetch detail for each schedule to get variables.
+		var detailed []*gl.PipelineSchedule
+		for _, s := range schedules {
+			slog.Debug("fetching pipeline schedule detail", "project", p.PathWithNamespace, "schedule", s.ID)
+			d, _, err := c.api.PipelineSchedules.GetPipelineSchedule(p.ID, s.ID, gl.WithContext(ctx))
+			if err != nil {
+				return nil, fmt.Errorf("getting pipeline schedule %d for project %d: %w", s.ID, p.ID, err)
+			}
+			detailed = append(detailed, d)
+		}
+
+		if len(detailed) > 0 {
+			result[p.ID] = detailed
+		}
+	}
+	return result, nil
+}

--- a/internal/skip/skip.go
+++ b/internal/skip/skip.go
@@ -16,7 +16,7 @@ var ResourceTypes = []string{
 	"variables",
 	"approval_rules",
 	"mr_approvals",
-	"pipeline_schedules",
+	"schedules",
 	"branch_protection",
 	"service_accounts",
 }

--- a/internal/terraform/import.go
+++ b/internal/terraform/import.go
@@ -121,6 +121,34 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 		}
 	}
 
+	if !skipSet.Has("schedules") {
+		for _, p := range resources.Projects {
+			if p == nil {
+				continue
+			}
+			for _, s := range resources.PipelineSchedules[p.ID] {
+				schedName := pipelineScheduleResourceName(p, s)
+				schedKey := "gitlab_pipeline_schedule." + schedName
+				if !existingResources[schedKey] {
+					cmds = append(cmds, ImportCommand{
+						Address: schedKey,
+						ID:      fmt.Sprintf("%d:%d", p.ID, s.ID),
+					})
+				}
+				for _, v := range s.Variables {
+					varName := pipelineScheduleVariableResourceName(p, s, v)
+					varKey := "gitlab_pipeline_schedule_variable." + varName
+					if !existingResources[varKey] {
+						cmds = append(cmds, ImportCommand{
+							Address: varKey,
+							ID:      fmt.Sprintf("%d:%d:%s", p.ID, s.ID, v.Key),
+						})
+					}
+				}
+			}
+		}
+	}
+
 	return cmds
 }
 

--- a/internal/terraform/import_test.go
+++ b/internal/terraform/import_test.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/xMoelletschi/terraform-gitlab-drift/internal/gitlab"
@@ -345,5 +346,79 @@ func TestPrintImportCommands(t *testing.T) {
 
 	if buf.String() != want {
 		t.Errorf("output mismatch:\ngot:\n%s\nwant:\n%s", buf.String(), want)
+	}
+}
+
+func TestGenerateImportCommandsNewPipelineSchedule(t *testing.T) {
+	resources := &gitlab.Resources{
+		Projects: []*gl.Project{
+			{
+				ID:   1,
+				Path: "my-project",
+				Namespace: &gl.ProjectNamespace{
+					FullPath: "parent",
+				},
+			},
+		},
+		PipelineSchedules: map[int64][]*gl.PipelineSchedule{
+			1: {
+				{
+					ID:          10,
+					Description: "Nightly build",
+					Variables: []*gl.PipelineVariable{
+						{Key: "DEPLOY_ENV", Value: "staging", VariableType: "env_var"},
+					},
+				},
+			},
+		},
+	}
+
+	existing := map[string]bool{
+		"gitlab_project.parent_my_project": true,
+	}
+
+	cmds := GenerateImportCommands(resources, existing, "parent", nil)
+
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 commands, got %d", len(cmds))
+	}
+	if cmds[0].Address != "gitlab_pipeline_schedule.parent_my_project_nightly_build" {
+		t.Errorf("address = %q, want %q", cmds[0].Address, "gitlab_pipeline_schedule.parent_my_project_nightly_build")
+	}
+	if cmds[0].ID != "1:10" {
+		t.Errorf("id = %q, want %q", cmds[0].ID, "1:10")
+	}
+	if cmds[1].Address != "gitlab_pipeline_schedule_variable.parent_my_project_nightly_build_deploy_env" {
+		t.Errorf("address = %q, want %q", cmds[1].Address, "gitlab_pipeline_schedule_variable.parent_my_project_nightly_build_deploy_env")
+	}
+	if cmds[1].ID != "1:10:DEPLOY_ENV" {
+		t.Errorf("id = %q, want %q", cmds[1].ID, "1:10:DEPLOY_ENV")
+	}
+}
+
+func TestGenerateImportCommandsSkipPipelineSchedules(t *testing.T) {
+	resources := &gitlab.Resources{
+		Groups: []*gl.Group{
+			{ID: 10, Path: "grp", FullPath: "grp"},
+		},
+		Projects: []*gl.Project{
+			{
+				ID:   1,
+				Path: "proj",
+				Namespace: &gl.ProjectNamespace{FullPath: "grp"},
+			},
+		},
+		PipelineSchedules: map[int64][]*gl.PipelineSchedule{
+			1: {{ID: 10, Description: "Nightly"}},
+		},
+	}
+
+	skipSet := skip.Set{"schedules": true}
+	cmds := GenerateImportCommands(resources, nil, "grp", skipSet)
+
+	for _, cmd := range cmds {
+		if strings.Contains(cmd.Address, "pipeline_schedule") {
+			t.Errorf("should not generate pipeline schedule import when skipped: %s", cmd.Address)
+		}
 	}
 }

--- a/internal/terraform/pipeline_schedules.go
+++ b/internal/terraform/pipeline_schedules.go
@@ -1,0 +1,69 @@
+package terraform
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+func normalizeName(s string) string {
+	normalized := strings.ToLower(s)
+	for _, ch := range []string{"/", "-", " ", "."} {
+		normalized = strings.ReplaceAll(normalized, ch, "_")
+	}
+	// Collapse consecutive underscores.
+	for strings.Contains(normalized, "__") {
+		normalized = strings.ReplaceAll(normalized, "__", "_")
+	}
+	normalized = strings.TrimRight(normalized, "_")
+	return normalized
+}
+
+func pipelineScheduleResourceName(p *gl.Project, s *gl.PipelineSchedule) string {
+	return projectResourceName(p) + "_" + normalizeName(s.Description)
+}
+
+func pipelineScheduleVariableResourceName(p *gl.Project, s *gl.PipelineSchedule, v *gl.PipelineVariable) string {
+	return pipelineScheduleResourceName(p, s) + "_" + normalizeName(v.Key)
+}
+
+func WritePipelineSchedules(p *gl.Project, schedules []*gl.PipelineSchedule, w io.Writer) error {
+	projName := projectResourceName(p)
+	for i, s := range schedules {
+		schedName := pipelineScheduleResourceName(p, s)
+		if i > 0 {
+			if _, err := fmt.Fprint(w, "\n"); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, `resource "gitlab_pipeline_schedule" "%s" {
+  project       = gitlab_project.%s.id
+  description   = "%s"
+  ref           = "%s"
+  cron          = "%s"
+  cron_timezone = "%s"
+  active        = %t
+}
+`, schedName, projName, s.Description, s.Ref, s.Cron, s.CronTimezone, s.Active); err != nil {
+			return err
+		}
+
+		for _, v := range s.Variables {
+			varName := pipelineScheduleVariableResourceName(p, s, v)
+			if _, err := fmt.Fprintf(w, `
+resource "gitlab_pipeline_schedule_variable" "%s" {
+  project              = gitlab_project.%s.id
+  pipeline_schedule_id = gitlab_pipeline_schedule.%s.pipeline_schedule_id
+  key                  = "%s"
+  value                = "%s"
+  variable_type        = "%s"
+}
+`, varName, projName, schedName, v.Key, v.Value, string(v.VariableType)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/terraform/pipeline_schedules_test.go
+++ b/internal/terraform/pipeline_schedules_test.go
@@ -1,0 +1,67 @@
+package terraform
+
+import (
+	"bytes"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+func TestWritePipelineSchedules(t *testing.T) {
+	project := &gl.Project{
+		ID:                1,
+		Path:              "my-project",
+		Namespace:         &gl.ProjectNamespace{FullPath: "my-group"},
+		PathWithNamespace: "my-group/my-project",
+	}
+
+	schedules := []*gl.PipelineSchedule{
+		{
+			ID:           10,
+			Description:  "Nightly build",
+			Ref:          "main",
+			Cron:         "0 2 * * *",
+			CronTimezone: "Europe/Vienna",
+			Active:       true,
+			Variables: []*gl.PipelineVariable{
+				{Key: "DEPLOY_ENV", Value: "staging", VariableType: "env_var"},
+			},
+		},
+		{
+			ID:           20,
+			Description:  "Weekly cleanup",
+			Ref:          "main",
+			Cron:         "0 0 * * 0",
+			CronTimezone: "UTC",
+			Active:       false,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WritePipelineSchedules(project, schedules, &buf); err != nil {
+		t.Fatalf("WritePipelineSchedules error: %v", err)
+	}
+
+	compareGolden(t, "pipeline_schedules.tf", buf.String())
+}
+
+func TestNormalizeName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Nightly build", "nightly_build"},
+		{"deploy/staging", "deploy_staging"},
+		{"my-pipeline", "my_pipeline"},
+		{"some.job.name", "some_job_name"},
+		{"a--b//c  d..e", "a_b_c_d_e"},
+		{"trailing-", "trailing"},
+		{"DEPLOY_ENV", "deploy_env"},
+	}
+	for _, tt := range tests {
+		got := normalizeName(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeName(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/terraform/testdata/pipeline_schedules.tf
+++ b/internal/terraform/testdata/pipeline_schedules.tf
@@ -1,0 +1,25 @@
+resource "gitlab_pipeline_schedule" "my_group_my_project_nightly_build" {
+  project       = gitlab_project.my_group_my_project.id
+  description   = "Nightly build"
+  ref           = "main"
+  cron          = "0 2 * * *"
+  cron_timezone = "Europe/Vienna"
+  active        = true
+}
+
+resource "gitlab_pipeline_schedule_variable" "my_group_my_project_nightly_build_deploy_env" {
+  project              = gitlab_project.my_group_my_project.id
+  pipeline_schedule_id = gitlab_pipeline_schedule.my_group_my_project_nightly_build.pipeline_schedule_id
+  key                  = "DEPLOY_ENV"
+  value                = "staging"
+  variable_type        = "env_var"
+}
+
+resource "gitlab_pipeline_schedule" "my_group_my_project_weekly_cleanup" {
+  project       = gitlab_project.my_group_my_project.id
+  description   = "Weekly cleanup"
+  ref           = "main"
+  cron          = "0 0 * * 0"
+  cron_timezone = "UTC"
+  active        = false
+}

--- a/internal/terraform/writer.go
+++ b/internal/terraform/writer.go
@@ -13,12 +13,8 @@ import (
 	gl "gitlab.com/gitlab-org/api/client-go"
 )
 
-func normalizeToTerraformName(path string) string {
-	normalized := strings.ToLower(path)
-	normalized = strings.ReplaceAll(normalized, "/", "_")
-	normalized = strings.ReplaceAll(normalized, "-", "_")
-
-	return normalized
+func normalizeToTerraformName(s string) string {
+	return normalizeName(s)
 }
 
 func WriteAll(resources *gitlab.Resources, dir string, mainGroup string, skipSet skip.Set) error {
@@ -101,6 +97,32 @@ func WriteAll(resources *gitlab.Resources, dir string, mainGroup string, skipSet
 			return WriteProjectLabelVariable(resources.Projects, resources.ProjectLabels, w)
 		}); err != nil {
 			errs = append(errs, fmt.Errorf("project_labels.tf: %w", err))
+		}
+	}
+
+	// Write pipeline_schedules.tf with individual resource blocks
+	if !skipSet.Has("schedules") {
+		if err := writeFile(filepath.Join(dir, "pipeline_schedules.tf"), func(w io.Writer) error {
+			first := true
+			for _, p := range resources.Projects {
+				if p == nil {
+					continue
+				}
+				if scheds := resources.PipelineSchedules[p.ID]; len(scheds) > 0 {
+					if !first {
+						if _, err := w.Write([]byte("\n")); err != nil {
+							return err
+						}
+					}
+					if err := WritePipelineSchedules(p, scheds, w); err != nil {
+						return err
+					}
+					first = false
+				}
+			}
+			return nil
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("pipeline_schedules.tf: %w", err))
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add `gitlab_pipeline_schedule` and `gitlab_pipeline_schedule_variable` as individual resource blocks (no variables/for_each)
- Schedules are written to a dedicated `pipeline_schedules.tf` file
- Add debug/info logging for all API fetch operations
- Consolidate name normalization (`normalizeToTerraformName` now delegates to `normalizeName`)

Closes #15

## Test plan
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] Manual test against live GitLab instance — output verified