### PR TITLE
feat: add support for gitlab_project_hook and gitlab_group_hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ terraform/
 ├── group_labels.tf         # generated: variable with group → labels
 ├── project_labels.tf       # generated: variable with project → labels
 ├── pipeline_schedules.tf   # generated: variable with project → pipeline schedules
+├── hooks.tf                # generated: project and group webhooks
 └── ...
 ```
 
@@ -103,6 +104,8 @@ terraform/
 - ✅ GitLab Project Labels ([`gitlab_project_label`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_label))
 - ✅ GitLab Pipeline Schedules ([`gitlab_pipeline_schedule`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/pipeline_schedule))
 - ✅ GitLab Pipeline Schedule Variables ([`gitlab_pipeline_schedule_variable`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/pipeline_schedule_variable))
+- ✅ GitLab Project Hooks ([`gitlab_project_hook`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_hook))
+- ✅ GitLab Group Hooks ([`gitlab_group_hook`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/group_hook)) *(requires Premium/Ultimate)*
 - 🚧 More resources coming soon
 
 ## Contributing

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -21,6 +21,8 @@ type Resources struct {
 	GroupLabels       GroupLabels
 	ProjectLabels     ProjectLabels
 	PipelineSchedules PipelineSchedules
+	ProjectHooks      ProjectHooks
+	GroupHooks        GroupHooks
 }
 
 func NewClientFromAPI(api *gl.Client, group string) *Client {
@@ -82,6 +84,22 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		slog.Info("fetched pipeline schedules", "count", len(pipelineSchedules))
 	}
 
+	var projectHooks ProjectHooks
+	var groupHooks GroupHooks
+	if !skipSet.Has("hooks") {
+		projectHooks, err = c.ListProjectHooks(ctx, projects)
+		if err != nil {
+			return nil, fmt.Errorf("listing project hooks: %w", err)
+		}
+		slog.Info("fetched project hooks", "count", len(projectHooks))
+
+		groupHooks, err = c.ListGroupHooks(ctx, groups)
+		if err != nil {
+			return nil, fmt.Errorf("listing group hooks: %w", err)
+		}
+		slog.Info("fetched group hooks", "count", len(groupHooks))
+	}
+
 	return &Resources{
 		Groups:            groups,
 		Projects:          projects,
@@ -89,5 +107,7 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		GroupLabels:       groupLabels,
 		ProjectLabels:     projectLabels,
 		PipelineSchedules: pipelineSchedules,
+		ProjectHooks:      projectHooks,
+		GroupHooks:        groupHooks,
 	}, nil
 }

--- a/internal/gitlab/hooks.go
+++ b/internal/gitlab/hooks.go
@@ -1,0 +1,88 @@
+package gitlab
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+// ProjectHooks maps project IDs to their hooks.
+type ProjectHooks = map[int64][]*gl.ProjectHook
+
+// GroupHooks maps group IDs to their hooks.
+type GroupHooks = map[int64][]*gl.GroupHook
+
+func (c *Client) ListProjectHooks(ctx context.Context, projects []*gl.Project) (ProjectHooks, error) {
+	result := make(ProjectHooks, len(projects))
+
+	for _, p := range projects {
+		if p == nil {
+			continue
+		}
+		slog.Debug("fetching project hooks", "project", p.PathWithNamespace)
+		opts := &gl.ListProjectHooksOptions{
+			ListOptions: gl.ListOptions{
+				Page:    1,
+				PerPage: 100,
+			},
+		}
+		var hooks []*gl.ProjectHook
+		for {
+			page, resp, err := c.api.Projects.ListProjectHooks(p.ID, opts, gl.WithContext(ctx))
+			if err != nil {
+				return nil, fmt.Errorf("listing hooks for project %d: %w", p.ID, err)
+			}
+			hooks = append(hooks, page...)
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+		if len(hooks) > 0 {
+			result[p.ID] = hooks
+		}
+	}
+	return result, nil
+}
+
+func (c *Client) ListGroupHooks(ctx context.Context, groups []*gl.Group) (GroupHooks, error) {
+	result := make(GroupHooks, len(groups))
+
+	for _, g := range groups {
+		if g == nil {
+			continue
+		}
+		slog.Debug("fetching group hooks", "group", g.FullPath)
+		opts := &gl.ListGroupHooksOptions{
+			ListOptions: gl.ListOptions{
+				Page:    1,
+				PerPage: 100,
+			},
+		}
+		var hooks []*gl.GroupHook
+		for {
+			page, resp, err := c.api.Groups.ListGroupHooks(g.ID, opts, gl.WithContext(ctx))
+			if err != nil {
+				var errResp *gl.ErrorResponse
+				if errors.As(err, &errResp) && errResp.HasStatusCode(http.StatusForbidden) {
+					slog.Warn("group hooks require Premium/Ultimate, skipping", "group", g.FullPath)
+					break
+				}
+				return nil, fmt.Errorf("listing hooks for group %d: %w", g.ID, err)
+			}
+			hooks = append(hooks, page...)
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+		if len(hooks) > 0 {
+			result[g.ID] = hooks
+		}
+	}
+	return result, nil
+}

--- a/internal/terraform/hooks.go
+++ b/internal/terraform/hooks.go
@@ -1,0 +1,149 @@
+package terraform
+
+import (
+	"io"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+func normalizeHookURL(rawURL string) string {
+	u := strings.TrimPrefix(rawURL, "https://")
+	u = strings.TrimPrefix(u, "http://")
+	u = strings.ReplaceAll(u, ":", "_")
+	return normalizeName(u)
+}
+
+func projectHookResourceName(p *gl.Project, h *gl.ProjectHook) string {
+	return projectResourceName(p) + "_" + normalizeHookURL(h.URL)
+}
+
+func groupHookResourceName(g *gl.Group, h *gl.GroupHook) string {
+	return normalizeToTerraformName(g.Path) + "_" + normalizeHookURL(h.URL)
+}
+
+func WriteProjectHooks(p *gl.Project, hooks []*gl.ProjectHook, w io.Writer) error {
+	f := hclwrite.NewEmptyFile()
+	rootBody := f.Body()
+	projName := projectResourceName(p)
+
+	for i, h := range hooks {
+		if i > 0 {
+			rootBody.AppendNewline()
+		}
+		name := projectHookResourceName(p, h)
+		block := rootBody.AppendNewBlock("resource", []string{"gitlab_project_hook", name})
+		body := block.Body()
+
+		body.SetAttributeTraversal("project", hcl.Traversal{
+			hcl.TraverseRoot{Name: "gitlab_project"},
+			hcl.TraverseAttr{Name: projName},
+			hcl.TraverseAttr{Name: "id"},
+		})
+		body.SetAttributeValue("url", cty.StringVal(h.URL))
+		if h.Name != "" {
+			body.SetAttributeValue("name", cty.StringVal(h.Name))
+		}
+		if h.Description != "" {
+			body.SetAttributeValue("description", cty.StringVal(h.Description))
+		}
+		body.SetAttributeValue("enable_ssl_verification", cty.BoolVal(h.EnableSSLVerification))
+
+		// push_events: always write (provider default is true, so we need explicit false)
+		body.SetAttributeValue("push_events", cty.BoolVal(h.PushEvents))
+		if h.PushEventsBranchFilter != "" {
+			body.SetAttributeValue("push_events_branch_filter", cty.StringVal(h.PushEventsBranchFilter))
+		}
+
+		writeEvents(body, []hookEvent{
+			{"tag_push_events", h.TagPushEvents},
+			{"issues_events", h.IssuesEvents},
+			{"confidential_issues_events", h.ConfidentialIssuesEvents},
+			{"merge_requests_events", h.MergeRequestsEvents},
+			{"note_events", h.NoteEvents},
+			{"confidential_note_events", h.ConfidentialNoteEvents},
+			{"job_events", h.JobEvents},
+			{"pipeline_events", h.PipelineEvents},
+			{"wiki_page_events", h.WikiPageEvents},
+			{"deployment_events", h.DeploymentEvents},
+			{"releases_events", h.ReleasesEvents},
+		})
+	}
+
+	_, err := w.Write(f.Bytes())
+	return err
+}
+
+func WriteGroupHooks(g *gl.Group, hooks []*gl.GroupHook, w io.Writer) error {
+	f := hclwrite.NewEmptyFile()
+	rootBody := f.Body()
+	groupName := normalizeToTerraformName(g.Path)
+
+	for i, h := range hooks {
+		if i > 0 {
+			rootBody.AppendNewline()
+		}
+		name := groupHookResourceName(g, h)
+		block := rootBody.AppendNewBlock("resource", []string{"gitlab_group_hook", name})
+		body := block.Body()
+
+		body.SetAttributeTraversal("group", hcl.Traversal{
+			hcl.TraverseRoot{Name: "gitlab_group"},
+			hcl.TraverseAttr{Name: groupName},
+			hcl.TraverseAttr{Name: "id"},
+		})
+		body.SetAttributeValue("url", cty.StringVal(h.URL))
+		if h.Name != "" {
+			body.SetAttributeValue("name", cty.StringVal(h.Name))
+		}
+		if h.Description != "" {
+			body.SetAttributeValue("description", cty.StringVal(h.Description))
+		}
+		body.SetAttributeValue("enable_ssl_verification", cty.BoolVal(h.EnableSSLVerification))
+
+		// push_events: always write
+		body.SetAttributeValue("push_events", cty.BoolVal(h.PushEvents))
+		if h.PushEventsBranchFilter != "" {
+			body.SetAttributeValue("push_events_branch_filter", cty.StringVal(h.PushEventsBranchFilter))
+		}
+		if h.BranchFilterStrategy != "" {
+			body.SetAttributeValue("branch_filter_strategy", cty.StringVal(h.BranchFilterStrategy))
+		}
+
+		writeEvents(body, []hookEvent{
+			{"tag_push_events", h.TagPushEvents},
+			{"issues_events", h.IssuesEvents},
+			{"confidential_issues_events", h.ConfidentialIssuesEvents},
+			{"merge_requests_events", h.MergeRequestsEvents},
+			{"note_events", h.NoteEvents},
+			{"confidential_note_events", h.ConfidentialNoteEvents},
+			{"job_events", h.JobEvents},
+			{"pipeline_events", h.PipelineEvents},
+			{"wiki_page_events", h.WikiPageEvents},
+			{"deployment_events", h.DeploymentEvents},
+			{"releases_events", h.ReleasesEvents},
+			{"subgroup_events", h.SubGroupEvents},
+			{"emoji_events", h.EmojiEvents},
+			{"feature_flag_events", h.FeatureFlagEvents},
+		})
+	}
+
+	_, err := w.Write(f.Bytes())
+	return err
+}
+
+type hookEvent struct {
+	attr string
+	val  bool
+}
+
+func writeEvents(body *hclwrite.Body, events []hookEvent) {
+	for _, e := range events {
+		if e.val {
+			body.SetAttributeValue(e.attr, cty.True)
+		}
+	}
+}

--- a/internal/terraform/hooks_test.go
+++ b/internal/terraform/hooks_test.go
@@ -1,0 +1,97 @@
+package terraform
+
+import (
+	"bytes"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+func TestNormalizeHookURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://hooks.slack.com/services/T123", "hooks_slack_com_services_t123"},
+		{"http://example.com/webhook", "example_com_webhook"},
+		{"https://example.com:8080/hook", "example_com_8080_hook"},
+		{"example.com/plain", "example_com_plain"},
+	}
+	for _, tt := range tests {
+		got := normalizeHookURL(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeHookURL(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestWriteProjectHooks(t *testing.T) {
+	project := &gl.Project{
+		ID:                1,
+		Path:              "my-project",
+		Namespace:         &gl.ProjectNamespace{FullPath: "my-group"},
+		PathWithNamespace: "my-group/my-project",
+	}
+
+	hooks := []*gl.ProjectHook{
+		{
+			ID:                    100,
+			URL:                   "https://hooks.slack.com/services/T123",
+			Name:                  "Slack notifications",
+			Description:           "Posts to #dev",
+			EnableSSLVerification: true,
+			PushEvents:            true,
+			MergeRequestsEvents:   true,
+		},
+		{
+			ID:                    200,
+			URL:                   "https://example.com/webhook",
+			EnableSSLVerification: true,
+			PushEvents:            false,
+			TagPushEvents:         true,
+			PipelineEvents:        true,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteProjectHooks(project, hooks, &buf); err != nil {
+		t.Fatalf("WriteProjectHooks error: %v", err)
+	}
+
+	compareGolden(t, "project_hooks.tf", buf.String())
+}
+
+func TestWriteGroupHooks(t *testing.T) {
+	group := &gl.Group{
+		ID:       10,
+		Path:     "my-group",
+		FullPath: "my-group",
+	}
+
+	hooks := []*gl.GroupHook{
+		{
+			ID:                    300,
+			URL:                   "https://example.com/webhook",
+			EnableSSLVerification: true,
+			PushEvents:            true,
+			SubGroupEvents:        true,
+		},
+		{
+			ID:                    400,
+			URL:                   "https://ci.internal.io/notify",
+			Name:                  "CI notify",
+			EnableSSLVerification: false,
+			PushEvents:            true,
+			MergeRequestsEvents:   true,
+			EmojiEvents:           true,
+			FeatureFlagEvents:     true,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteGroupHooks(group, hooks, &buf); err != nil {
+		t.Fatalf("WriteGroupHooks error: %v", err)
+	}
+
+	compareGolden(t, "group_hooks.tf", buf.String())
+}

--- a/internal/terraform/import.go
+++ b/internal/terraform/import.go
@@ -121,6 +121,40 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 		}
 	}
 
+	if !skipSet.Has("hooks") {
+		for _, g := range resources.Groups {
+			if g == nil {
+				continue
+			}
+			for _, h := range resources.GroupHooks[g.ID] {
+				name := groupHookResourceName(g, h)
+				key := "gitlab_group_hook." + name
+				if !existingResources[key] {
+					cmds = append(cmds, ImportCommand{
+						Address: key,
+						ID:      fmt.Sprintf("%d:%d", g.ID, h.ID),
+					})
+				}
+			}
+		}
+
+		for _, p := range resources.Projects {
+			if p == nil {
+				continue
+			}
+			for _, h := range resources.ProjectHooks[p.ID] {
+				name := projectHookResourceName(p, h)
+				key := "gitlab_project_hook." + name
+				if !existingResources[key] {
+					cmds = append(cmds, ImportCommand{
+						Address: key,
+						ID:      fmt.Sprintf("%d:%d", p.ID, h.ID),
+					})
+				}
+			}
+		}
+	}
+
 	if !skipSet.Has("schedules") {
 		for _, p := range resources.Projects {
 			if p == nil {

--- a/internal/terraform/import_test.go
+++ b/internal/terraform/import_test.go
@@ -396,6 +396,100 @@ func TestGenerateImportCommandsNewPipelineSchedule(t *testing.T) {
 	}
 }
 
+func TestGenerateImportCommandsNewProjectHook(t *testing.T) {
+	resources := &gitlab.Resources{
+		Projects: []*gl.Project{
+			{
+				ID:   1,
+				Path: "my-project",
+				Namespace: &gl.ProjectNamespace{
+					FullPath: "parent",
+				},
+			},
+		},
+		ProjectHooks: map[int64][]*gl.ProjectHook{
+			1: {
+				{ID: 50, URL: "https://hooks.slack.com/services/T123"},
+			},
+		},
+	}
+
+	existing := map[string]bool{
+		"gitlab_project.parent_my_project": true,
+	}
+
+	cmds := GenerateImportCommands(resources, existing, "parent", nil)
+
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(cmds))
+	}
+	if cmds[0].Address != "gitlab_project_hook.parent_my_project_hooks_slack_com_services_t123" {
+		t.Errorf("address = %q, want %q", cmds[0].Address, "gitlab_project_hook.parent_my_project_hooks_slack_com_services_t123")
+	}
+	if cmds[0].ID != "1:50" {
+		t.Errorf("id = %q, want %q", cmds[0].ID, "1:50")
+	}
+}
+
+func TestGenerateImportCommandsNewGroupHook(t *testing.T) {
+	resources := &gitlab.Resources{
+		Groups: []*gl.Group{
+			{ID: 10, Path: "my-group", FullPath: "my-group"},
+		},
+		GroupHooks: map[int64][]*gl.GroupHook{
+			10: {
+				{ID: 60, URL: "https://example.com/webhook"},
+			},
+		},
+	}
+
+	existing := map[string]bool{
+		"gitlab_group.my_group": true,
+	}
+
+	cmds := GenerateImportCommands(resources, existing, "my-group", nil)
+
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(cmds))
+	}
+	if cmds[0].Address != "gitlab_group_hook.my_group_example_com_webhook" {
+		t.Errorf("address = %q, want %q", cmds[0].Address, "gitlab_group_hook.my_group_example_com_webhook")
+	}
+	if cmds[0].ID != "10:60" {
+		t.Errorf("id = %q, want %q", cmds[0].ID, "10:60")
+	}
+}
+
+func TestGenerateImportCommandsSkipHooks(t *testing.T) {
+	resources := &gitlab.Resources{
+		Groups: []*gl.Group{
+			{ID: 10, Path: "grp", FullPath: "grp"},
+		},
+		Projects: []*gl.Project{
+			{
+				ID:   1,
+				Path: "proj",
+				Namespace: &gl.ProjectNamespace{FullPath: "grp"},
+			},
+		},
+		ProjectHooks: map[int64][]*gl.ProjectHook{
+			1: {{ID: 50, URL: "https://example.com/hook"}},
+		},
+		GroupHooks: map[int64][]*gl.GroupHook{
+			10: {{ID: 60, URL: "https://example.com/hook"}},
+		},
+	}
+
+	skipSet := skip.Set{"hooks": true}
+	cmds := GenerateImportCommands(resources, nil, "grp", skipSet)
+
+	for _, cmd := range cmds {
+		if strings.Contains(cmd.Address, "_hook.") {
+			t.Errorf("should not generate hook import when skipped: %s", cmd.Address)
+		}
+	}
+}
+
 func TestGenerateImportCommandsSkipPipelineSchedules(t *testing.T) {
 	resources := &gitlab.Resources{
 		Groups: []*gl.Group{

--- a/internal/terraform/testdata/group_hooks.tf
+++ b/internal/terraform/testdata/group_hooks.tf
@@ -1,0 +1,18 @@
+resource "gitlab_group_hook" "my_group_example_com_webhook" {
+  group                   = gitlab_group.my_group.id
+  url                     = "https://example.com/webhook"
+  enable_ssl_verification = true
+  push_events             = true
+  subgroup_events         = true
+}
+
+resource "gitlab_group_hook" "my_group_ci_internal_io_notify" {
+  group                   = gitlab_group.my_group.id
+  url                     = "https://ci.internal.io/notify"
+  name                    = "CI notify"
+  enable_ssl_verification = false
+  push_events             = true
+  merge_requests_events   = true
+  emoji_events            = true
+  feature_flag_events     = true
+}

--- a/internal/terraform/testdata/project_hooks.tf
+++ b/internal/terraform/testdata/project_hooks.tf
@@ -1,0 +1,18 @@
+resource "gitlab_project_hook" "my_group_my_project_hooks_slack_com_services_t123" {
+  project                 = gitlab_project.my_group_my_project.id
+  url                     = "https://hooks.slack.com/services/T123"
+  name                    = "Slack notifications"
+  description             = "Posts to #dev"
+  enable_ssl_verification = true
+  push_events             = true
+  merge_requests_events   = true
+}
+
+resource "gitlab_project_hook" "my_group_my_project_example_com_webhook" {
+  project                 = gitlab_project.my_group_my_project.id
+  url                     = "https://example.com/webhook"
+  enable_ssl_verification = true
+  push_events             = false
+  tag_push_events         = true
+  pipeline_events         = true
+}

--- a/internal/terraform/writer.go
+++ b/internal/terraform/writer.go
@@ -126,6 +126,48 @@ func WriteAll(resources *gitlab.Resources, dir string, mainGroup string, skipSet
 		}
 	}
 
+	// Write hooks.tf with individual resource blocks
+	if !skipSet.Has("hooks") {
+		if err := writeFile(filepath.Join(dir, "hooks.tf"), func(w io.Writer) error {
+			first := true
+			for _, g := range resources.Groups {
+				if g == nil {
+					continue
+				}
+				if hooks := resources.GroupHooks[g.ID]; len(hooks) > 0 {
+					if !first {
+						if _, err := w.Write([]byte("\n")); err != nil {
+							return err
+						}
+					}
+					if err := WriteGroupHooks(g, hooks, w); err != nil {
+						return err
+					}
+					first = false
+				}
+			}
+			for _, p := range resources.Projects {
+				if p == nil {
+					continue
+				}
+				if hooks := resources.ProjectHooks[p.ID]; len(hooks) > 0 {
+					if !first {
+						if _, err := w.Write([]byte("\n")); err != nil {
+							return err
+						}
+					}
+					if err := WriteProjectHooks(p, hooks, w); err != nil {
+						return err
+					}
+					first = false
+				}
+			}
+			return nil
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("hooks.tf: %w", err))
+		}
+	}
+
 	// Write one file per namespace: group → group membership resource → projects → project share group resources
 	for ns := range allNamespaces {
 		trimmedNs := strings.TrimPrefix(ns, mainGroup+"/")


### PR DESCRIPTION
## Summary

Closes #11

- Add `gitlab_project_hook` and `gitlab_group_hook` drift detection, generating individual resource blocks in `hooks.tf`
- Group hooks handle 403 gracefully (Premium/Ultimate required — logs warning and skips)
- Uses `hclwrite` for proper HCL formatting consistent with the rest of the codebase
- Adds `":"` to `normalizeName` so webhook URLs normalize cleanly

## Changes

- `internal/gitlab/hooks.go` — `ListProjectHooks` / `ListGroupHooks` with pagination
- `internal/gitlab/client.go` — `ProjectHooks` / `GroupHooks` in `Resources`, fetched in `FetchAll`
- `internal/terraform/hooks.go` — HCL generation via `hclwrite` for both hook types
- `internal/terraform/writer.go` — `hooks.tf` output block
- `internal/terraform/import.go` — import command generation (`project_id:hook_id` / `group_id:hook_id`)
- `internal/terraform/pipeline_schedules.go` — added `:` to `normalizeName`
- `README.md` — documented new resources

## Test plan

- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] Manual test against live GitLab instance