### PR TITLE
feat: add support for gitlab_project_variable and gitlab_group_variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ terraform/
 ├── project_membership.tf   # generated: variable with project → shared groups
 ├── group_labels.tf         # generated: variable with group → labels
 ├── project_labels.tf       # generated: variable with project → labels
+├── ci_variables.tf         # generated: group and project CI/CD variables
 ├── pipeline_schedules.tf   # generated: variable with project → pipeline schedules
 ├── hooks.tf                # generated: project and group webhooks
 └── ...
@@ -104,9 +105,18 @@ terraform/
 - ✅ GitLab Project Labels ([`gitlab_project_label`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_label))
 - ✅ GitLab Pipeline Schedules ([`gitlab_pipeline_schedule`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/pipeline_schedule))
 - ✅ GitLab Pipeline Schedule Variables ([`gitlab_pipeline_schedule_variable`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/pipeline_schedule_variable))
+- ✅ GitLab Group Variables ([`gitlab_group_variable`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/group_variable)) *
+- ✅ GitLab Project Variables ([`gitlab_project_variable`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_variable)) *
 - ✅ GitLab Project Hooks ([`gitlab_project_hook`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_hook))
 - ✅ GitLab Group Hooks ([`gitlab_group_hook`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/group_hook)) *(requires Premium/Ultimate)*
 - 🚧 More resources coming soon
+
+> **\* CI/CD Variable Filtering:** Masked variables and file-type variables are automatically skipped.
+> Masked variables are excluded because the GitLab API returns redacted values (`[MASKED]`), which would produce invalid Terraform state.
+> File-type variables are excluded because they typically contain sensitive data such as SSH private keys or certificates.
+>
+> **Important:** If you store secrets (SSH keys, API tokens, etc.) as `env_var`-type CI/CD variables, they will be written to `.tf` files in plaintext.
+> To prevent this, store sensitive values as **file-type** variables — this is also [GitLab's recommended approach](https://docs.gitlab.com/ci/variables/#use-file-type-cicd-variables) for multi-line secrets like SSH keys, since they cannot be masked.
 
 ## Contributing
 

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -23,6 +23,8 @@ type Resources struct {
 	PipelineSchedules PipelineSchedules
 	ProjectHooks      ProjectHooks
 	GroupHooks        GroupHooks
+	ProjectVariables  ProjectVariables
+	GroupVariables    GroupVariables
 }
 
 func NewClientFromAPI(api *gl.Client, group string) *Client {
@@ -84,6 +86,22 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		slog.Info("fetched pipeline schedules", "count", len(pipelineSchedules))
 	}
 
+	var projectVariables ProjectVariables
+	var groupVariables GroupVariables
+	if !skipSet.Has("variables") {
+		groupVariables, err = c.ListGroupVariables(ctx, groups)
+		if err != nil {
+			return nil, fmt.Errorf("listing group variables: %w", err)
+		}
+		slog.Info("fetched group variables", "count", len(groupVariables))
+
+		projectVariables, err = c.ListProjectVariables(ctx, projects)
+		if err != nil {
+			return nil, fmt.Errorf("listing project variables: %w", err)
+		}
+		slog.Info("fetched project variables", "count", len(projectVariables))
+	}
+
 	var projectHooks ProjectHooks
 	var groupHooks GroupHooks
 	if !skipSet.Has("hooks") {
@@ -109,5 +127,7 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		PipelineSchedules: pipelineSchedules,
 		ProjectHooks:      projectHooks,
 		GroupHooks:        groupHooks,
+		ProjectVariables:  projectVariables,
+		GroupVariables:    groupVariables,
 	}, nil
 }

--- a/internal/gitlab/variables.go
+++ b/internal/gitlab/variables.go
@@ -1,0 +1,111 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+// ProjectVariables maps project IDs to their CI/CD variables.
+type ProjectVariables = map[int64][]*gl.ProjectVariable
+
+// GroupVariables maps group IDs to their CI/CD variables.
+type GroupVariables = map[int64][]*gl.GroupVariable
+
+func (c *Client) ListProjectVariables(ctx context.Context, projects []*gl.Project) (ProjectVariables, error) {
+	result := make(ProjectVariables, len(projects))
+
+	for _, p := range projects {
+		if p == nil {
+			continue
+		}
+		slog.Debug("fetching project variables", "project", p.PathWithNamespace)
+		opts := &gl.ListProjectVariablesOptions{
+			ListOptions: gl.ListOptions{
+				Page:    1,
+				PerPage: 100,
+			},
+		}
+		var vars []*gl.ProjectVariable
+		for {
+			page, resp, err := c.api.ProjectVariables.ListVariables(p.ID, opts, gl.WithContext(ctx))
+			if err != nil {
+				return nil, fmt.Errorf("listing variables for project %d: %w", p.ID, err)
+			}
+			for _, v := range page {
+				if v.Masked {
+					slog.Warn("skipping masked variable", "key", v.Key, "project", p.PathWithNamespace)
+					continue
+				}
+				if v.Hidden {
+					slog.Warn("skipping hidden variable", "key", v.Key, "project", p.PathWithNamespace)
+					continue
+				}
+				if v.VariableType == gl.FileVariableType {
+					slog.Warn("skipping file variable", "key", v.Key, "project", p.PathWithNamespace)
+					continue
+				}
+				vars = append(vars, v)
+			}
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+		if len(vars) > 0 {
+			result[p.ID] = vars
+		}
+	}
+
+	return result, nil
+}
+
+func (c *Client) ListGroupVariables(ctx context.Context, groups []*gl.Group) (GroupVariables, error) {
+	result := make(GroupVariables, len(groups))
+
+	for _, g := range groups {
+		if g == nil {
+			continue
+		}
+		slog.Debug("fetching group variables", "group", g.FullPath)
+		opts := &gl.ListGroupVariablesOptions{
+			ListOptions: gl.ListOptions{
+				Page:    1,
+				PerPage: 100,
+			},
+		}
+		var vars []*gl.GroupVariable
+		for {
+			page, resp, err := c.api.GroupVariables.ListVariables(g.ID, opts, gl.WithContext(ctx))
+			if err != nil {
+				return nil, fmt.Errorf("listing variables for group %d: %w", g.ID, err)
+			}
+			for _, v := range page {
+				if v.Masked {
+					slog.Warn("skipping masked variable", "key", v.Key, "group", g.FullPath)
+					continue
+				}
+				if v.Hidden {
+					slog.Warn("skipping hidden variable", "key", v.Key, "group", g.FullPath)
+					continue
+				}
+				if v.VariableType == gl.FileVariableType {
+					slog.Warn("skipping file variable", "key", v.Key, "group", g.FullPath)
+					continue
+				}
+				vars = append(vars, v)
+			}
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+		if len(vars) > 0 {
+			result[g.ID] = vars
+		}
+	}
+
+	return result, nil
+}

--- a/internal/terraform/import.go
+++ b/internal/terraform/import.go
@@ -121,6 +121,40 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 		}
 	}
 
+	if !skipSet.Has("variables") {
+		for _, g := range resources.Groups {
+			if g == nil {
+				continue
+			}
+			for _, v := range resources.GroupVariables[g.ID] {
+				name := groupVariableResourceName(g, v)
+				key := "gitlab_group_variable." + name
+				if !existingResources[key] {
+					cmds = append(cmds, ImportCommand{
+						Address: key,
+						ID:      fmt.Sprintf("%d:%s:%s", g.ID, v.Key, v.EnvironmentScope),
+					})
+				}
+			}
+		}
+
+		for _, p := range resources.Projects {
+			if p == nil {
+				continue
+			}
+			for _, v := range resources.ProjectVariables[p.ID] {
+				name := projectVariableResourceName(p, v)
+				key := "gitlab_project_variable." + name
+				if !existingResources[key] {
+					cmds = append(cmds, ImportCommand{
+						Address: key,
+						ID:      fmt.Sprintf("%d:%s:%s", p.ID, v.Key, v.EnvironmentScope),
+					})
+				}
+			}
+		}
+	}
+
 	if !skipSet.Has("hooks") {
 		for _, g := range resources.Groups {
 			if g == nil {

--- a/internal/terraform/import_test.go
+++ b/internal/terraform/import_test.go
@@ -490,6 +490,107 @@ func TestGenerateImportCommandsSkipHooks(t *testing.T) {
 	}
 }
 
+func TestGenerateImportCommandsNewGroupVariable(t *testing.T) {
+	resources := &gitlab.Resources{
+		Groups: []*gl.Group{
+			{ID: 10, Path: "my-group", FullPath: "my-group"},
+		},
+		GroupVariables: map[int64][]*gl.GroupVariable{
+			10: {
+				{Key: "API_URL", EnvironmentScope: "*"},
+				{Key: "DB_HOST", EnvironmentScope: "production"},
+			},
+		},
+	}
+
+	existing := map[string]bool{
+		"gitlab_group.my_group": true,
+	}
+
+	cmds := GenerateImportCommands(resources, existing, "my-group", nil)
+
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 commands, got %d", len(cmds))
+	}
+	if cmds[0].Address != "gitlab_group_variable.my_group_api_url" {
+		t.Errorf("address = %q, want %q", cmds[0].Address, "gitlab_group_variable.my_group_api_url")
+	}
+	if cmds[0].ID != "10:API_URL:*" {
+		t.Errorf("id = %q, want %q", cmds[0].ID, "10:API_URL:*")
+	}
+	if cmds[1].Address != "gitlab_group_variable.my_group_db_host_production" {
+		t.Errorf("address = %q, want %q", cmds[1].Address, "gitlab_group_variable.my_group_db_host_production")
+	}
+	if cmds[1].ID != "10:DB_HOST:production" {
+		t.Errorf("id = %q, want %q", cmds[1].ID, "10:DB_HOST:production")
+	}
+}
+
+func TestGenerateImportCommandsNewProjectVariable(t *testing.T) {
+	resources := &gitlab.Resources{
+		Projects: []*gl.Project{
+			{
+				ID:   1,
+				Path: "my-project",
+				Namespace: &gl.ProjectNamespace{
+					FullPath: "parent",
+				},
+			},
+		},
+		ProjectVariables: map[int64][]*gl.ProjectVariable{
+			1: {
+				{Key: "SECRET_KEY", EnvironmentScope: "*"},
+			},
+		},
+	}
+
+	existing := map[string]bool{
+		"gitlab_project.parent_my_project": true,
+	}
+
+	cmds := GenerateImportCommands(resources, existing, "parent", nil)
+
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(cmds))
+	}
+	if cmds[0].Address != "gitlab_project_variable.parent_my_project_secret_key" {
+		t.Errorf("address = %q, want %q", cmds[0].Address, "gitlab_project_variable.parent_my_project_secret_key")
+	}
+	if cmds[0].ID != "1:SECRET_KEY:*" {
+		t.Errorf("id = %q, want %q", cmds[0].ID, "1:SECRET_KEY:*")
+	}
+}
+
+func TestGenerateImportCommandsSkipVariables(t *testing.T) {
+	resources := &gitlab.Resources{
+		Groups: []*gl.Group{
+			{ID: 10, Path: "grp", FullPath: "grp"},
+		},
+		Projects: []*gl.Project{
+			{
+				ID:   1,
+				Path: "proj",
+				Namespace: &gl.ProjectNamespace{FullPath: "grp"},
+			},
+		},
+		GroupVariables: map[int64][]*gl.GroupVariable{
+			10: {{Key: "VAR1", EnvironmentScope: "*"}},
+		},
+		ProjectVariables: map[int64][]*gl.ProjectVariable{
+			1: {{Key: "VAR2", EnvironmentScope: "*"}},
+		},
+	}
+
+	skipSet := skip.Set{"variables": true}
+	cmds := GenerateImportCommands(resources, nil, "grp", skipSet)
+
+	for _, cmd := range cmds {
+		if strings.Contains(cmd.Address, "_variable.") {
+			t.Errorf("should not generate variable import when skipped: %s", cmd.Address)
+		}
+	}
+}
+
 func TestGenerateImportCommandsSkipPipelineSchedules(t *testing.T) {
 	resources := &gitlab.Resources{
 		Groups: []*gl.Group{

--- a/internal/terraform/testdata/group_variables.tf
+++ b/internal/terraform/testdata/group_variables.tf
@@ -1,0 +1,19 @@
+resource "gitlab_group_variable" "my_group_api_url" {
+  group         = gitlab_group.my_group.id
+  key           = "API_URL"
+  value         = "https://api.example.com"
+  variable_type = "env_var"
+  protected     = false
+  raw           = true
+  description   = "API base URL"
+}
+
+resource "gitlab_group_variable" "my_group_db_host_production" {
+  group             = gitlab_group.my_group.id
+  key               = "DB_HOST"
+  value             = "db.example.com"
+  variable_type     = "env_var"
+  protected         = true
+  raw               = false
+  environment_scope = "production"
+}

--- a/internal/terraform/testdata/project_variables.tf
+++ b/internal/terraform/testdata/project_variables.tf
@@ -1,0 +1,9 @@
+resource "gitlab_project_variable" "my_group_my_project_secret_key" {
+  project       = gitlab_project.my_group_my_project.id
+  key           = "SECRET_KEY"
+  value         = "abc123"
+  variable_type = "env_var"
+  protected     = false
+  raw           = false
+  description   = "Secret key"
+}

--- a/internal/terraform/variables.go
+++ b/internal/terraform/variables.go
@@ -1,0 +1,90 @@
+package terraform
+
+import (
+	"io"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+func variableResourceName(owner, key, envScope string) string {
+	name := owner + "_" + key
+	if envScope != "*" {
+		name += "_" + envScope
+	}
+	return normalizeName(name)
+}
+
+func groupVariableResourceName(g *gl.Group, v *gl.GroupVariable) string {
+	return variableResourceName(g.Path, v.Key, v.EnvironmentScope)
+}
+
+func projectVariableResourceName(p *gl.Project, v *gl.ProjectVariable) string {
+	return variableResourceName(projectResourceName(p), v.Key, v.EnvironmentScope)
+}
+
+func writeVariableAttrs(body *hclwrite.Body, key, value, varType, envScope, description string, protected, raw bool) {
+	body.SetAttributeValue("key", cty.StringVal(key))
+	body.SetAttributeValue("value", cty.StringVal(value))
+	body.SetAttributeValue("variable_type", cty.StringVal(varType))
+	body.SetAttributeValue("protected", cty.BoolVal(protected))
+	body.SetAttributeValue("raw", cty.BoolVal(raw))
+	if envScope != "*" {
+		body.SetAttributeValue("environment_scope", cty.StringVal(envScope))
+	}
+	if description != "" {
+		body.SetAttributeValue("description", cty.StringVal(description))
+	}
+}
+
+func WriteGroupVariables(g *gl.Group, vars []*gl.GroupVariable, w io.Writer) error {
+	f := hclwrite.NewEmptyFile()
+	rootBody := f.Body()
+	groupName := normalizeToTerraformName(g.Path)
+
+	for i, v := range vars {
+		if i > 0 {
+			rootBody.AppendNewline()
+		}
+		name := groupVariableResourceName(g, v)
+		block := rootBody.AppendNewBlock("resource", []string{"gitlab_group_variable", name})
+		body := block.Body()
+
+		body.SetAttributeTraversal("group", hcl.Traversal{
+			hcl.TraverseRoot{Name: "gitlab_group"},
+			hcl.TraverseAttr{Name: groupName},
+			hcl.TraverseAttr{Name: "id"},
+		})
+		writeVariableAttrs(body, v.Key, v.Value, string(v.VariableType), v.EnvironmentScope, v.Description, v.Protected, v.Raw)
+	}
+
+	_, err := w.Write(f.Bytes())
+	return err
+}
+
+func WriteProjectVariables(p *gl.Project, vars []*gl.ProjectVariable, w io.Writer) error {
+	f := hclwrite.NewEmptyFile()
+	rootBody := f.Body()
+	projName := projectResourceName(p)
+
+	for i, v := range vars {
+		if i > 0 {
+			rootBody.AppendNewline()
+		}
+		name := projectVariableResourceName(p, v)
+		block := rootBody.AppendNewBlock("resource", []string{"gitlab_project_variable", name})
+		body := block.Body()
+
+		body.SetAttributeTraversal("project", hcl.Traversal{
+			hcl.TraverseRoot{Name: "gitlab_project"},
+			hcl.TraverseAttr{Name: projName},
+			hcl.TraverseAttr{Name: "id"},
+		})
+		writeVariableAttrs(body, v.Key, v.Value, string(v.VariableType), v.EnvironmentScope, v.Description, v.Protected, v.Raw)
+	}
+
+	_, err := w.Write(f.Bytes())
+	return err
+}

--- a/internal/terraform/variables_test.go
+++ b/internal/terraform/variables_test.go
@@ -1,0 +1,84 @@
+package terraform
+
+import (
+	"bytes"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+func TestWriteGroupVariables(t *testing.T) {
+	group := &gl.Group{ID: 10, Path: "my-group", FullPath: "my-group"}
+	vars := []*gl.GroupVariable{
+		{
+			Key:              "API_URL",
+			Value:            "https://api.example.com",
+			VariableType:     "env_var",
+			Protected:        false,
+			Raw:              true,
+			EnvironmentScope: "*",
+			Description:      "API base URL",
+		},
+		{
+			Key:              "DB_HOST",
+			Value:            "db.example.com",
+			VariableType:     "env_var",
+			Protected:        true,
+			Raw:              false,
+			EnvironmentScope: "production",
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteGroupVariables(group, vars, &buf); err != nil {
+		t.Fatalf("WriteGroupVariables error: %v", err)
+	}
+
+	compareGolden(t, "group_variables.tf", buf.String())
+}
+
+func TestWriteProjectVariables(t *testing.T) {
+	project := &gl.Project{
+		ID:   1,
+		Path: "my-project",
+		Namespace: &gl.ProjectNamespace{
+			FullPath: "my-group",
+		},
+		PathWithNamespace: "my-group/my-project",
+	}
+	vars := []*gl.ProjectVariable{
+		{
+			Key:              "SECRET_KEY",
+			Value:            "abc123",
+			VariableType:     "env_var",
+			Protected:        false,
+			Raw:              false,
+			EnvironmentScope: "*",
+			Description:      "Secret key",
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteProjectVariables(project, vars, &buf); err != nil {
+		t.Fatalf("WriteProjectVariables error: %v", err)
+	}
+
+	compareGolden(t, "project_variables.tf", buf.String())
+}
+
+func TestGroupVariableResourceName(t *testing.T) {
+	g := &gl.Group{Path: "my-group"}
+	tests := []struct {
+		v    *gl.GroupVariable
+		want string
+	}{
+		{&gl.GroupVariable{Key: "API_URL", EnvironmentScope: "*"}, "my_group_api_url"},
+		{&gl.GroupVariable{Key: "DB_HOST", EnvironmentScope: "production"}, "my_group_db_host_production"},
+	}
+	for _, tt := range tests {
+		got := groupVariableResourceName(g, tt.v)
+		if got != tt.want {
+			t.Errorf("groupVariableResourceName(%q, %q) = %q, want %q", tt.v.Key, tt.v.EnvironmentScope, got, tt.want)
+		}
+	}
+}

--- a/internal/terraform/writer.go
+++ b/internal/terraform/writer.go
@@ -100,6 +100,48 @@ func WriteAll(resources *gitlab.Resources, dir string, mainGroup string, skipSet
 		}
 	}
 
+	// Write ci_variables.tf with individual resource blocks
+	if !skipSet.Has("variables") {
+		if err := writeFile(filepath.Join(dir, "ci_variables.tf"), func(w io.Writer) error {
+			first := true
+			for _, g := range resources.Groups {
+				if g == nil {
+					continue
+				}
+				if vars := resources.GroupVariables[g.ID]; len(vars) > 0 {
+					if !first {
+						if _, err := w.Write([]byte("\n")); err != nil {
+							return err
+						}
+					}
+					if err := WriteGroupVariables(g, vars, w); err != nil {
+						return err
+					}
+					first = false
+				}
+			}
+			for _, p := range resources.Projects {
+				if p == nil {
+					continue
+				}
+				if vars := resources.ProjectVariables[p.ID]; len(vars) > 0 {
+					if !first {
+						if _, err := w.Write([]byte("\n")); err != nil {
+							return err
+						}
+					}
+					if err := WriteProjectVariables(p, vars, w); err != nil {
+						return err
+					}
+					first = false
+				}
+			}
+			return nil
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("ci_variables.tf: %w", err))
+		}
+	}
+
 	// Write pipeline_schedules.tf with individual resource blocks
 	if !skipSet.Has("schedules") {
 		if err := writeFile(filepath.Join(dir, "pipeline_schedules.tf"), func(w io.Writer) error {


### PR DESCRIPTION
## Summary

- Add support for `gitlab_project_variable` and `gitlab_group_variable` resource generation (#10)
- Generate individual resource blocks per variable using `hclwrite` for proper HCL escaping
- Skip masked, hidden, and file-type variables to avoid writing sensitive data to `.tf` files
- Generate `terraform import` commands for new variables

## Filtering

Skipped variables (with warning log):
- **Masked** — API returns `[MASKED]`, producing invalid Terraform state
- **Hidden** — API returns empty value (GitLab 17.4+)
- **File-type** — typically contain sensitive data (SSH keys, certificates)

Non-masked `env_var` variables (e.g. `LOG_LEVEL`, `API_URL`) are written with their actual values.

## Test plan

- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] Manual test against live GitLab instance