### PR TITLE
feat: add support for gitlab_branch_protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ terraform/
 ├── ci_variables.tf         # generated: group and project CI/CD variables
 ├── pipeline_schedules.tf   # generated: variable with project → pipeline schedules
 ├── hooks.tf                # generated: project and group webhooks
+├── branch_protections.tf   # generated: project branch protection rules
 └── ...
 ```
 
@@ -109,6 +110,7 @@ terraform/
 - ✅ GitLab Project Variables ([`gitlab_project_variable`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_variable)) *
 - ✅ GitLab Project Hooks ([`gitlab_project_hook`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_hook))
 - ✅ GitLab Group Hooks ([`gitlab_group_hook`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/group_hook)) *(requires Premium/Ultimate)*
+- ✅ GitLab Branch Protection ([`gitlab_branch_protection`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/branch_protection)) **
 - 🚧 More resources coming soon
 
 > **\* CI/CD Variable Filtering:** Masked variables and file-type variables are automatically skipped.
@@ -117,6 +119,9 @@ terraform/
 >
 > **Important:** If you store secrets (SSH keys, API tokens, etc.) as `env_var`-type CI/CD variables, they will be written to `.tf` files in plaintext.
 > To prevent this, store sensitive values as **file-type** variables — this is also [GitLab's recommended approach](https://docs.gitlab.com/ci/variables/#use-file-type-cicd-variables) for multi-line secrets like SSH keys, since they cannot be masked.
+>
+> **\*\* Branch Protection:** The `allowed_to_push`, `allowed_to_merge`, `allowed_to_unprotect`, `unprotect_access_level`, and `code_owner_approval_required` attributes require a GitLab Premium/Ultimate instance.
+> These attributes are included by default but can be excluded with `--skip premium`. When skipped, only the free-tier attributes (`push_access_level`, `merge_access_level`, `allow_force_push`) are generated.
 
 ## Contributing
 

--- a/internal/gitlab/branch_protections.go
+++ b/internal/gitlab/branch_protections.go
@@ -1,0 +1,45 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+// ProtectedBranches maps project IDs to their protected branches.
+type ProtectedBranches = map[int64][]*gl.ProtectedBranch
+
+func (c *Client) ListProtectedBranches(ctx context.Context, projects []*gl.Project) (ProtectedBranches, error) {
+	result := make(ProtectedBranches, len(projects))
+
+	for _, p := range projects {
+		if p == nil {
+			continue
+		}
+		slog.Debug("fetching protected branches", "project", p.PathWithNamespace)
+		opts := &gl.ListProtectedBranchesOptions{
+			ListOptions: gl.ListOptions{
+				Page:    1,
+				PerPage: 100,
+			},
+		}
+		var branches []*gl.ProtectedBranch
+		for {
+			page, resp, err := c.api.ProtectedBranches.ListProtectedBranches(p.ID, opts, gl.WithContext(ctx))
+			if err != nil {
+				return nil, fmt.Errorf("listing protected branches for project %d: %w", p.ID, err)
+			}
+			branches = append(branches, page...)
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+		if len(branches) > 0 {
+			result[p.ID] = branches
+		}
+	}
+	return result, nil
+}

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -25,6 +25,7 @@ type Resources struct {
 	GroupHooks        GroupHooks
 	ProjectVariables  ProjectVariables
 	GroupVariables    GroupVariables
+	ProtectedBranches ProtectedBranches
 }
 
 func NewClientFromAPI(api *gl.Client, group string) *Client {
@@ -102,6 +103,15 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		slog.Info("fetched project variables", "count", len(projectVariables))
 	}
 
+	var protectedBranches ProtectedBranches
+	if !skipSet.Has("branch_protection") {
+		protectedBranches, err = c.ListProtectedBranches(ctx, projects)
+		if err != nil {
+			return nil, fmt.Errorf("listing protected branches: %w", err)
+		}
+		slog.Info("fetched protected branches", "count", len(protectedBranches))
+	}
+
 	var projectHooks ProjectHooks
 	var groupHooks GroupHooks
 	if !skipSet.Has("hooks") {
@@ -129,5 +139,6 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		GroupHooks:        groupHooks,
 		ProjectVariables:  projectVariables,
 		GroupVariables:    groupVariables,
+		ProtectedBranches: protectedBranches,
 	}, nil
 }

--- a/internal/skip/skip.go
+++ b/internal/skip/skip.go
@@ -38,6 +38,7 @@ func Parse(input []string) (Set, []string) {
 
 	for _, name := range input {
 		if members, ok := Groups[name]; ok {
+			set[name] = true
 			for _, m := range members {
 				set[m] = true
 			}

--- a/internal/terraform/branch_protections.go
+++ b/internal/terraform/branch_protections.go
@@ -1,0 +1,126 @@
+package terraform
+
+import (
+	"io"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+func normalizeBranchName(s string) string {
+	s = strings.ReplaceAll(s, "*", "wildcard")
+	return normalizeName(s)
+}
+
+func branchProtectionResourceName(p *gl.Project, b *gl.ProtectedBranch) string {
+	return projectResourceName(p) + "_" + normalizeBranchName(b.Name)
+}
+
+const adminAccessLevel gl.AccessLevelValue = 60
+
+func branchProtectionAccessLevel(level gl.AccessLevelValue) string {
+	switch level {
+	case gl.NoPermissions:
+		return "no one"
+	case gl.DeveloperPermissions:
+		return "developer"
+	case gl.MaintainerPermissions:
+		return "maintainer"
+	case adminAccessLevel:
+		return "admin"
+	default:
+		return "maintainer"
+	}
+}
+
+func isBaseAccessLevel(l *gl.BranchAccessDescription) bool {
+	return l.UserID == 0 && l.GroupID == 0 && l.DeployKeyID == 0
+}
+
+// baseAccessLevel returns the access level from the entry that represents
+// the overall branch access level (no specific user/group/deploy key).
+func baseAccessLevel(levels []*gl.BranchAccessDescription) gl.AccessLevelValue {
+	for _, l := range levels {
+		if isBaseAccessLevel(l) {
+			return l.AccessLevel
+		}
+	}
+	if len(levels) > 0 {
+		return levels[0].AccessLevel
+	}
+	return gl.MaintainerPermissions
+}
+
+func WriteBranchProtections(p *gl.Project, branches []*gl.ProtectedBranch, premium bool, w io.Writer) error {
+	f := hclwrite.NewEmptyFile()
+	rootBody := f.Body()
+	projName := projectResourceName(p)
+
+	for i, b := range branches {
+		if i > 0 {
+			rootBody.AppendNewline()
+		}
+		name := branchProtectionResourceName(p, b)
+		block := rootBody.AppendNewBlock("resource", []string{"gitlab_branch_protection", name})
+		body := block.Body()
+
+		body.SetAttributeTraversal("project", hcl.Traversal{
+			hcl.TraverseRoot{Name: "gitlab_project"},
+			hcl.TraverseAttr{Name: projName},
+			hcl.TraverseAttr{Name: "id"},
+		})
+		body.SetAttributeValue("branch", cty.StringVal(b.Name))
+
+		pushLevel := baseAccessLevel(b.PushAccessLevels)
+		mergeLevel := baseAccessLevel(b.MergeAccessLevels)
+
+		body.SetAttributeValue("push_access_level", cty.StringVal(branchProtectionAccessLevel(pushLevel)))
+		body.SetAttributeValue("merge_access_level", cty.StringVal(branchProtectionAccessLevel(mergeLevel)))
+
+		if premium {
+			unprotectLevel := baseAccessLevel(b.UnprotectAccessLevels)
+			if unprotectLevel != gl.MaintainerPermissions {
+				body.SetAttributeValue("unprotect_access_level", cty.StringVal(branchProtectionAccessLevel(unprotectLevel)))
+			}
+		}
+
+		if b.AllowForcePush {
+			body.SetAttributeValue("allow_force_push", cty.True)
+		}
+
+		if premium && b.CodeOwnerApprovalRequired {
+			body.SetAttributeValue("code_owner_approval_required", cty.True)
+		}
+
+		if premium {
+			writeAccessBlocks(body, "allowed_to_push", b.PushAccessLevels)
+			writeAccessBlocks(body, "allowed_to_merge", b.MergeAccessLevels)
+			writeAccessBlocks(body, "allowed_to_unprotect", b.UnprotectAccessLevels)
+		}
+	}
+
+	_, err := w.Write(f.Bytes())
+	return err
+}
+
+func writeAccessBlocks(body *hclwrite.Body, blockName string, levels []*gl.BranchAccessDescription) {
+	for _, l := range levels {
+		if isBaseAccessLevel(l) {
+			continue
+		}
+		nested := body.AppendNewBlock(blockName, nil)
+		nb := nested.Body()
+		if l.UserID != 0 {
+			nb.SetAttributeValue("user_id", cty.NumberIntVal(l.UserID))
+		}
+		if l.GroupID != 0 {
+			nb.SetAttributeValue("group_id", cty.NumberIntVal(l.GroupID))
+		}
+		if l.DeployKeyID != 0 {
+			nb.SetAttributeValue("deploy_key_id", cty.NumberIntVal(l.DeployKeyID))
+		}
+	}
+}

--- a/internal/terraform/branch_protections_test.go
+++ b/internal/terraform/branch_protections_test.go
@@ -1,0 +1,127 @@
+package terraform
+
+import (
+	"bytes"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+func TestBranchProtectionResourceName(t *testing.T) {
+	project := &gl.Project{
+		Path:      "my-project",
+		Namespace: &gl.ProjectNamespace{FullPath: "my-group"},
+	}
+	branch := &gl.ProtectedBranch{Name: "main"}
+	got := branchProtectionResourceName(project, branch)
+	want := "my_group_my_project_main"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBranchProtectionResourceNameWildcard(t *testing.T) {
+	project := &gl.Project{
+		Path:      "my-project",
+		Namespace: &gl.ProjectNamespace{FullPath: "my-group"},
+	}
+	branch := &gl.ProtectedBranch{Name: "release/*"}
+	got := branchProtectionResourceName(project, branch)
+	want := "my_group_my_project_release_wildcard"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteBranchProtections_Free(t *testing.T) {
+	project := &gl.Project{
+		ID:                1,
+		Path:              "my-project",
+		Namespace:         &gl.ProjectNamespace{FullPath: "my-group"},
+		PathWithNamespace: "my-group/my-project",
+	}
+
+	branches := []*gl.ProtectedBranch{
+		{
+			ID:   1,
+			Name: "main",
+			PushAccessLevels: []*gl.BranchAccessDescription{
+				{AccessLevel: gl.MaintainerPermissions},
+			},
+			MergeAccessLevels: []*gl.BranchAccessDescription{
+				{AccessLevel: gl.DeveloperPermissions},
+			},
+			AllowForcePush:            false,
+			CodeOwnerApprovalRequired: true, // should be ignored in free mode
+		},
+		{
+			ID:   2,
+			Name: "release/*",
+			PushAccessLevels: []*gl.BranchAccessDescription{
+				{AccessLevel: gl.NoPermissions},
+			},
+			MergeAccessLevels: []*gl.BranchAccessDescription{
+				{AccessLevel: gl.MaintainerPermissions},
+			},
+			AllowForcePush: true,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteBranchProtections(project, branches, false, &buf); err != nil {
+		t.Fatalf("WriteBranchProtections error: %v", err)
+	}
+
+	compareGolden(t, "branch_protections_free.tf", buf.String())
+}
+
+func TestWriteBranchProtections_Premium(t *testing.T) {
+	project := &gl.Project{
+		ID:                1,
+		Path:              "my-project",
+		Namespace:         &gl.ProjectNamespace{FullPath: "my-group"},
+		PathWithNamespace: "my-group/my-project",
+	}
+
+	branches := []*gl.ProtectedBranch{
+		{
+			ID:   1,
+			Name: "main",
+			PushAccessLevels: []*gl.BranchAccessDescription{
+				{AccessLevel: gl.MaintainerPermissions},
+				{AccessLevel: gl.DeveloperPermissions, UserID: 5},
+				{AccessLevel: gl.DeveloperPermissions, UserID: 10},
+			},
+			MergeAccessLevels: []*gl.BranchAccessDescription{
+				{AccessLevel: gl.DeveloperPermissions},
+				{AccessLevel: gl.DeveloperPermissions, GroupID: 42},
+			},
+			UnprotectAccessLevels: []*gl.BranchAccessDescription{
+				{AccessLevel: gl.DeveloperPermissions},
+			},
+			AllowForcePush:            false,
+			CodeOwnerApprovalRequired: true,
+		},
+		{
+			ID:   2,
+			Name: "develop",
+			PushAccessLevels: []*gl.BranchAccessDescription{
+				{AccessLevel: gl.DeveloperPermissions},
+			},
+			MergeAccessLevels: []*gl.BranchAccessDescription{
+				{AccessLevel: gl.DeveloperPermissions},
+			},
+			UnprotectAccessLevels: []*gl.BranchAccessDescription{
+				{AccessLevel: gl.MaintainerPermissions},
+			},
+			AllowForcePush: true,
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteBranchProtections(project, branches, true, &buf); err != nil {
+		t.Fatalf("WriteBranchProtections error: %v", err)
+	}
+
+	compareGolden(t, "branch_protections_premium.tf", buf.String())
+}

--- a/internal/terraform/import.go
+++ b/internal/terraform/import.go
@@ -155,6 +155,24 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 		}
 	}
 
+	if !skipSet.Has("branch_protection") {
+		for _, p := range resources.Projects {
+			if p == nil {
+				continue
+			}
+			for _, b := range resources.ProtectedBranches[p.ID] {
+				name := branchProtectionResourceName(p, b)
+				key := "gitlab_branch_protection." + name
+				if !existingResources[key] {
+					cmds = append(cmds, ImportCommand{
+						Address: key,
+						ID:      fmt.Sprintf("%d:%s", p.ID, b.Name),
+					})
+				}
+			}
+		}
+	}
+
 	if !skipSet.Has("hooks") {
 		for _, g := range resources.Groups {
 			if g == nil {

--- a/internal/terraform/testdata/branch_protections_free.tf
+++ b/internal/terraform/testdata/branch_protections_free.tf
@@ -1,0 +1,14 @@
+resource "gitlab_branch_protection" "my_group_my_project_main" {
+  project            = gitlab_project.my_group_my_project.id
+  branch             = "main"
+  push_access_level  = "maintainer"
+  merge_access_level = "developer"
+}
+
+resource "gitlab_branch_protection" "my_group_my_project_release_wildcard" {
+  project            = gitlab_project.my_group_my_project.id
+  branch             = "release/*"
+  push_access_level  = "no one"
+  merge_access_level = "maintainer"
+  allow_force_push   = true
+}

--- a/internal/terraform/testdata/branch_protections_premium.tf
+++ b/internal/terraform/testdata/branch_protections_premium.tf
@@ -1,0 +1,25 @@
+resource "gitlab_branch_protection" "my_group_my_project_main" {
+  project                      = gitlab_project.my_group_my_project.id
+  branch                       = "main"
+  push_access_level            = "maintainer"
+  merge_access_level           = "developer"
+  unprotect_access_level       = "developer"
+  code_owner_approval_required = true
+  allowed_to_push {
+    user_id = 5
+  }
+  allowed_to_push {
+    user_id = 10
+  }
+  allowed_to_merge {
+    group_id = 42
+  }
+}
+
+resource "gitlab_branch_protection" "my_group_my_project_develop" {
+  project            = gitlab_project.my_group_my_project.id
+  branch             = "develop"
+  push_access_level  = "developer"
+  merge_access_level = "developer"
+  allow_force_push   = true
+}

--- a/internal/terraform/writer.go
+++ b/internal/terraform/writer.go
@@ -168,6 +168,33 @@ func WriteAll(resources *gitlab.Resources, dir string, mainGroup string, skipSet
 		}
 	}
 
+	// Write branch_protections.tf with individual resource blocks
+	if !skipSet.Has("branch_protection") {
+		premium := !skipSet.Has("premium")
+		if err := writeFile(filepath.Join(dir, "branch_protections.tf"), func(w io.Writer) error {
+			first := true
+			for _, p := range resources.Projects {
+				if p == nil {
+					continue
+				}
+				if branches := resources.ProtectedBranches[p.ID]; len(branches) > 0 {
+					if !first {
+						if _, err := w.Write([]byte("\n")); err != nil {
+							return err
+						}
+					}
+					if err := WriteBranchProtections(p, branches, premium, w); err != nil {
+						return err
+					}
+					first = false
+				}
+			}
+			return nil
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("branch_protections.tf: %w", err))
+		}
+	}
+
 	// Write hooks.tf with individual resource blocks
 	if !skipSet.Has("hooks") {
 		if err := writeFile(filepath.Join(dir, "hooks.tf"), func(w io.Writer) error {


### PR DESCRIPTION
## Summary
- Adds `gitlab_branch_protection` resource generation with tier-aware output (#19)
- **Free tier**: generates `push_access_level`, `merge_access_level`, `allow_force_push`
- **Premium**: additionally generates `allowed_to_push`/`allowed_to_merge`/`allowed_to_unprotect` nested blocks, `unprotect_access_level`, and `code_owner_approval_required`
- Premium attributes included by default, excluded with `--skip premium`
- Fixes `skip.Parse` to store group names in the set so `skipSet.Has("premium")` works

## Test plan
- [x] Golden file tests for free-tier output (`branch_protections_free.tf`)
- [x] Golden file tests for premium output (`branch_protections_premium.tf`)
- [x] Resource name tests including wildcard branches (`release/*` → `release_wildcard`)
- [x] All existing tests pass
- [x] Manual test with real GitLab instance

Closes #19