### PR TITLE
fix: branch protection, cleanup, and misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ When drift is detected, this creates (or updates) a merge request in the current
 | `--overwrite`     | -                    | `false`              | Overwrite files in terraform directory            |
 | `--show-diff`     | -                    | `true`               | Show diff between generated and existing files    |
 | `--skip`          | -                    | -                    | Resource types to skip (comma-separated). Use `premium` to skip all Premium-tier resources |
+| `--include`       | -                    | -                    | Resource types to opt back in (comma-separated). Use to enable resources skipped by default (currently `branch_protection`) |
 | `--create-mr`     | -                    | `false`              | Create a merge request with generated Terraform code |
 | `--target-repo`   | -                    | *(auto-detected)*    | GitLab project path or ID for the MR              |
 | `--mr-branch`     | -                    | `drift/backtrack`    | Branch name for the drift MR                      |
@@ -110,7 +111,7 @@ terraform/
 - ✅ GitLab Project Variables ([`gitlab_project_variable`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_variable)) *
 - ✅ GitLab Project Hooks ([`gitlab_project_hook`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_hook))
 - ✅ GitLab Group Hooks ([`gitlab_group_hook`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/group_hook)) *(requires Premium/Ultimate)*
-- ✅ GitLab Branch Protection ([`gitlab_branch_protection`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/branch_protection)) **
+- 🚧 GitLab Branch Protection ([`gitlab_branch_protection`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/branch_protection)) — *skipped by default, opt in with `--include branch_protection`* **
 - 🚧 More resources coming soon
 
 > **\* CI/CD Variable Filtering:** Masked variables and file-type variables are automatically skipped.
@@ -120,8 +121,14 @@ terraform/
 > **Important:** If you store secrets (SSH keys, API tokens, etc.) as `env_var`-type CI/CD variables, they will be written to `.tf` files in plaintext.
 > To prevent this, store sensitive values as **file-type** variables — this is also [GitLab's recommended approach](https://docs.gitlab.com/ci/variables/#use-file-type-cicd-variables) for multi-line secrets like SSH keys, since they cannot be masked.
 >
-> **\*\* Branch Protection:** The `allowed_to_push`, `allowed_to_merge`, `allowed_to_unprotect`, `unprotect_access_level`, and `code_owner_approval_required` attributes require a GitLab Premium/Ultimate instance.
-> These attributes are included by default but can be excluded with `--skip premium`. When skipped, only the free-tier attributes (`push_access_level`, `merge_access_level`, `allow_force_push`) are generated.
+> **\*\* Branch Protection (skipped by default):** The `gitlab_branch_protection` resource is currently skipped by default because of an upstream provider bug —
+> the provider's `Read` function does not populate `unprotect_access_level` into Terraform state on Free tier, which causes every `terraform plan` to mark every
+> protected branch for forced replacement. Enable it explicitly with `--include branch_protection` once your instance is Premium/Ultimate or once the upstream
+> provider bug is fixed.
+>
+> When enabled, the `allowed_to_push`, `allowed_to_merge`, `allowed_to_unprotect`, `unprotect_access_level`, and `code_owner_approval_required` attributes
+> require a GitLab Premium/Ultimate instance. They are emitted by default but can be excluded with `--skip premium`. When skipped, only the free-tier
+> attributes (`push_access_level`, `merge_access_level`, `allow_force_push`) are generated.
 
 ## Contributing
 

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -18,13 +18,14 @@ import (
 )
 
 var (
-	createMR      bool
-	overwrite     bool
-	showDiff      bool
-	skipResources []string
-	targetRepo    string
-	mrDestPath    string
-	mrBranch      string
+	createMR         bool
+	overwrite        bool
+	showDiff         bool
+	skipResources    []string
+	includeResources []string
+	targetRepo       string
+	mrDestPath       string
+	mrBranch         string
 )
 
 var scanCmd = &cobra.Command{
@@ -39,6 +40,7 @@ func init() {
 	scanCmd.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite files in terraform directory (default: write to tmp/ subdirectory)")
 	scanCmd.Flags().BoolVar(&showDiff, "show-diff", true, "Show diff between generated and existing files")
 	scanCmd.Flags().StringSliceVar(&skipResources, "skip", nil, "Resource types to skip (comma-separated). Use 'premium' to skip all Premium-tier resources")
+	scanCmd.Flags().StringSliceVar(&includeResources, "include", nil, "Resource types to opt back in (comma-separated). Use to enable resources that are skipped by default (currently: branch_protection)")
 	scanCmd.Flags().StringVar(&targetRepo, "target-repo", "", "GitLab project path or ID for the MR (default: detected from git remote in --terraform-dir)")
 	scanCmd.Flags().StringVar(&mrDestPath, "mr-dest-path", "", "Path within target repo where .tf files go (default: root)")
 	scanCmd.Flags().StringVar(&mrBranch, "mr-branch", "drift/backtrack", "Branch name for the drift MR")
@@ -67,9 +69,9 @@ func runScan(cmd *cobra.Command, args []string) error {
 		slog.Info("detected target repo from git remote", "target_repo", targetRepo)
 	}
 
-	skipSet, skipWarnings := skip.Parse(skipResources)
+	skipSet, skipWarnings := skip.Resolve(skipResources, includeResources)
 	for _, w := range skipWarnings {
-		slog.Warn("unknown skip value, ignoring", "name", w)
+		slog.Warn("unknown skip/include value, ignoring", "name", w)
 	}
 	if len(skipSet) > 0 {
 		skipped := make([]string, 0, len(skipSet))

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -231,6 +231,10 @@ func runScan(cmd *cobra.Command, args []string) error {
 		slog.Info("overwrote terraform files", "dir", terraformDir)
 	}
 
+	if err := os.RemoveAll(outputDir); err != nil {
+		slog.Debug("failed to clean up tmp directory", "err", err)
+	}
+
 	if driftFound {
 		slog.Warn("drift detected")
 		os.Exit(1)

--- a/internal/gitlab/groups.go
+++ b/internal/gitlab/groups.go
@@ -38,7 +38,7 @@ func (c *Client) ListGroups(ctx context.Context) ([]*gl.Group, error) {
 			}
 			opts.Page = resp.NextPage
 		}
-		return allGroups, nil
+		return filterDeletedGroups(allGroups), nil
 	}
 
 	opts := &gl.ListGroupsOptions{
@@ -58,5 +58,17 @@ func (c *Client) ListGroups(ctx context.Context) ([]*gl.Group, error) {
 		}
 		opts.Page = resp.NextPage
 	}
-	return allGroups, nil
+	return filterDeletedGroups(allGroups), nil
+}
+
+func filterDeletedGroups(groups []*gl.Group) []*gl.Group {
+	filtered := make([]*gl.Group, 0, len(groups))
+	for _, g := range groups {
+		if g.MarkedForDeletionOn != nil {
+			slog.Debug("skipping group pending deletion", "group", g.FullPath)
+			continue
+		}
+		filtered = append(filtered, g)
+	}
+	return filtered
 }

--- a/internal/gitlab/projects.go
+++ b/internal/gitlab/projects.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	gl "gitlab.com/gitlab-org/api/client-go"
 )
@@ -29,7 +30,7 @@ func (c *Client) ListProjects(ctx context.Context) ([]*gl.Project, error) {
 			}
 			opts.Page = resp.NextPage
 		}
-		return allProjects, nil
+		return filterDeletedProjects(allProjects), nil
 	}
 
 	opts := &gl.ListProjectsOptions{
@@ -49,5 +50,17 @@ func (c *Client) ListProjects(ctx context.Context) ([]*gl.Project, error) {
 		}
 		opts.Page = resp.NextPage
 	}
-	return allProjects, nil
+	return filterDeletedProjects(allProjects), nil
+}
+
+func filterDeletedProjects(projects []*gl.Project) []*gl.Project {
+	filtered := make([]*gl.Project, 0, len(projects))
+	for _, p := range projects {
+		if p.MarkedForDeletionOn != nil {
+			slog.Debug("skipping project pending deletion", "project", p.PathWithNamespace)
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	return filtered
 }

--- a/internal/gitlab/variables.go
+++ b/internal/gitlab/variables.go
@@ -36,15 +36,15 @@ func (c *Client) ListProjectVariables(ctx context.Context, projects []*gl.Projec
 			}
 			for _, v := range page {
 				if v.Masked {
-					slog.Warn("skipping masked variable", "key", v.Key, "project", p.PathWithNamespace)
+					slog.Debug("skipping masked variable", "key", v.Key, "project", p.PathWithNamespace)
 					continue
 				}
 				if v.Hidden {
-					slog.Warn("skipping hidden variable", "key", v.Key, "project", p.PathWithNamespace)
+					slog.Debug("skipping hidden variable", "key", v.Key, "project", p.PathWithNamespace)
 					continue
 				}
 				if v.VariableType == gl.FileVariableType {
-					slog.Warn("skipping file variable", "key", v.Key, "project", p.PathWithNamespace)
+					slog.Debug("skipping file variable", "key", v.Key, "project", p.PathWithNamespace)
 					continue
 				}
 				vars = append(vars, v)
@@ -84,15 +84,15 @@ func (c *Client) ListGroupVariables(ctx context.Context, groups []*gl.Group) (Gr
 			}
 			for _, v := range page {
 				if v.Masked {
-					slog.Warn("skipping masked variable", "key", v.Key, "group", g.FullPath)
+					slog.Debug("skipping masked variable", "key", v.Key, "group", g.FullPath)
 					continue
 				}
 				if v.Hidden {
-					slog.Warn("skipping hidden variable", "key", v.Key, "group", g.FullPath)
+					slog.Debug("skipping hidden variable", "key", v.Key, "group", g.FullPath)
 					continue
 				}
 				if v.VariableType == gl.FileVariableType {
-					slog.Warn("skipping file variable", "key", v.Key, "group", g.FullPath)
+					slog.Debug("skipping file variable", "key", v.Key, "group", g.FullPath)
 					continue
 				}
 				vars = append(vars, v)

--- a/internal/skip/skip.go
+++ b/internal/skip/skip.go
@@ -26,6 +26,13 @@ var Groups = map[string][]string{
 	"premium": {"hooks", "approval_rules", "mr_approvals", "service_accounts"},
 }
 
+// DefaultSkipped lists resource types that are skipped unless the user
+// explicitly opts in via --include. Currently contains branch_protection
+// because the gitlabhq/gitlab provider's Read does not populate
+// unprotect_access_level into state on Free tier, causing perpetual
+// ForceNew drift on every plan.
+var DefaultSkipped = []string{"branch_protection"}
+
 // Parse resolves group names, validates resource type names, and returns
 // the resulting Set plus any unknown names as warnings.
 func Parse(input []string) (Set, []string) {
@@ -49,6 +56,37 @@ func Parse(input []string) (Set, []string) {
 			continue
 		}
 		warnings = append(warnings, name)
+	}
+
+	if len(set) == 0 {
+		return nil, warnings
+	}
+	return set, warnings
+}
+
+// Resolve combines --skip values with default-skipped resources, with --include
+// allowing opt-in for any of the defaults. Returns the resolved skip set and
+// warnings for unknown names from either input.
+func Resolve(skipInput, includeInput []string) (Set, []string) {
+	set, warnings := Parse(skipInput)
+	if set == nil {
+		set = make(Set)
+	}
+
+	included := make(Set)
+	for _, name := range includeInput {
+		if !slices.Contains(ResourceTypes, name) {
+			warnings = append(warnings, name)
+			continue
+		}
+		included[name] = true
+	}
+
+	for _, name := range DefaultSkipped {
+		if included[name] {
+			continue
+		}
+		set[name] = true
 	}
 
 	if len(set) == 0 {

--- a/internal/skip/skip_test.go
+++ b/internal/skip/skip_test.go
@@ -98,3 +98,42 @@ func TestParseMixed(t *testing.T) {
 		t.Error("expected hooks from premium group")
 	}
 }
+
+func TestResolveAddsDefaults(t *testing.T) {
+	set, warnings := Resolve(nil, nil)
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	for _, name := range DefaultSkipped {
+		if !set.Has(name) {
+			t.Errorf("expected default-skipped %q in set", name)
+		}
+	}
+}
+
+func TestResolveIncludeOptsIn(t *testing.T) {
+	set, warnings := Resolve(nil, []string{"branch_protection"})
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if set.Has("branch_protection") {
+		t.Error("branch_protection should not be skipped after --include")
+	}
+}
+
+func TestResolveExplicitSkipKeepsResource(t *testing.T) {
+	set, _ := Resolve([]string{"hooks"}, []string{"branch_protection"})
+	if !set.Has("hooks") {
+		t.Error("expected hooks in set from --skip")
+	}
+	if set.Has("branch_protection") {
+		t.Error("branch_protection should not be skipped after --include")
+	}
+}
+
+func TestResolveUnknownIncludeWarns(t *testing.T) {
+	_, warnings := Resolve(nil, []string{"foobar"})
+	if !slices.Contains(warnings, "foobar") {
+		t.Errorf("expected foobar in warnings, got %v", warnings)
+	}
+}

--- a/internal/terraform/branch_protections.go
+++ b/internal/terraform/branch_protections.go
@@ -80,12 +80,8 @@ func WriteBranchProtections(p *gl.Project, branches []*gl.ProtectedBranch, premi
 		body.SetAttributeValue("push_access_level", cty.StringVal(branchProtectionAccessLevel(pushLevel)))
 		body.SetAttributeValue("merge_access_level", cty.StringVal(branchProtectionAccessLevel(mergeLevel)))
 
-		if premium {
-			unprotectLevel := baseAccessLevel(b.UnprotectAccessLevels)
-			if unprotectLevel != gl.MaintainerPermissions {
-				body.SetAttributeValue("unprotect_access_level", cty.StringVal(branchProtectionAccessLevel(unprotectLevel)))
-			}
-		}
+		unprotectLevel := baseAccessLevel(b.UnprotectAccessLevels)
+		body.SetAttributeValue("unprotect_access_level", cty.StringVal(branchProtectionAccessLevel(unprotectLevel)))
 
 		if b.AllowForcePush {
 			body.SetAttributeValue("allow_force_push", cty.True)

--- a/internal/terraform/branch_protections.go
+++ b/internal/terraform/branch_protections.go
@@ -80,18 +80,18 @@ func WriteBranchProtections(p *gl.Project, branches []*gl.ProtectedBranch, premi
 		body.SetAttributeValue("push_access_level", cty.StringVal(branchProtectionAccessLevel(pushLevel)))
 		body.SetAttributeValue("merge_access_level", cty.StringVal(branchProtectionAccessLevel(mergeLevel)))
 
-		unprotectLevel := baseAccessLevel(b.UnprotectAccessLevels)
-		body.SetAttributeValue("unprotect_access_level", cty.StringVal(branchProtectionAccessLevel(unprotectLevel)))
-
 		if b.AllowForcePush {
 			body.SetAttributeValue("allow_force_push", cty.True)
 		}
 
-		if premium && b.CodeOwnerApprovalRequired {
-			body.SetAttributeValue("code_owner_approval_required", cty.True)
-		}
-
 		if premium {
+			unprotectLevel := baseAccessLevel(b.UnprotectAccessLevels)
+			body.SetAttributeValue("unprotect_access_level", cty.StringVal(branchProtectionAccessLevel(unprotectLevel)))
+
+			if b.CodeOwnerApprovalRequired {
+				body.SetAttributeValue("code_owner_approval_required", cty.True)
+			}
+
 			writeAccessBlocks(body, "allowed_to_push", b.PushAccessLevels)
 			writeAccessBlocks(body, "allowed_to_merge", b.MergeAccessLevels)
 			writeAccessBlocks(body, "allowed_to_unprotect", b.UnprotectAccessLevels)

--- a/internal/terraform/testdata/branch_protections_free.tf
+++ b/internal/terraform/testdata/branch_protections_free.tf
@@ -1,14 +1,16 @@
 resource "gitlab_branch_protection" "my_group_my_project_main" {
-  project            = gitlab_project.my_group_my_project.id
-  branch             = "main"
-  push_access_level  = "maintainer"
-  merge_access_level = "developer"
+  project                = gitlab_project.my_group_my_project.id
+  branch                 = "main"
+  push_access_level      = "maintainer"
+  merge_access_level     = "developer"
+  unprotect_access_level = "maintainer"
 }
 
 resource "gitlab_branch_protection" "my_group_my_project_release_wildcard" {
-  project            = gitlab_project.my_group_my_project.id
-  branch             = "release/*"
-  push_access_level  = "no one"
-  merge_access_level = "maintainer"
-  allow_force_push   = true
+  project                = gitlab_project.my_group_my_project.id
+  branch                 = "release/*"
+  push_access_level      = "no one"
+  merge_access_level     = "maintainer"
+  unprotect_access_level = "maintainer"
+  allow_force_push       = true
 }

--- a/internal/terraform/testdata/branch_protections_free.tf
+++ b/internal/terraform/testdata/branch_protections_free.tf
@@ -1,16 +1,14 @@
 resource "gitlab_branch_protection" "my_group_my_project_main" {
-  project                = gitlab_project.my_group_my_project.id
-  branch                 = "main"
-  push_access_level      = "maintainer"
-  merge_access_level     = "developer"
-  unprotect_access_level = "maintainer"
+  project            = gitlab_project.my_group_my_project.id
+  branch             = "main"
+  push_access_level  = "maintainer"
+  merge_access_level = "developer"
 }
 
 resource "gitlab_branch_protection" "my_group_my_project_release_wildcard" {
-  project                = gitlab_project.my_group_my_project.id
-  branch                 = "release/*"
-  push_access_level      = "no one"
-  merge_access_level     = "maintainer"
-  unprotect_access_level = "maintainer"
-  allow_force_push       = true
+  project            = gitlab_project.my_group_my_project.id
+  branch             = "release/*"
+  push_access_level  = "no one"
+  merge_access_level = "maintainer"
+  allow_force_push   = true
 }

--- a/internal/terraform/testdata/branch_protections_premium.tf
+++ b/internal/terraform/testdata/branch_protections_premium.tf
@@ -21,6 +21,6 @@ resource "gitlab_branch_protection" "my_group_my_project_develop" {
   branch                 = "develop"
   push_access_level      = "developer"
   merge_access_level     = "developer"
-  unprotect_access_level = "maintainer"
   allow_force_push       = true
+  unprotect_access_level = "maintainer"
 }

--- a/internal/terraform/testdata/branch_protections_premium.tf
+++ b/internal/terraform/testdata/branch_protections_premium.tf
@@ -17,9 +17,10 @@ resource "gitlab_branch_protection" "my_group_my_project_main" {
 }
 
 resource "gitlab_branch_protection" "my_group_my_project_develop" {
-  project            = gitlab_project.my_group_my_project.id
-  branch             = "develop"
-  push_access_level  = "developer"
-  merge_access_level = "developer"
-  allow_force_push   = true
+  project                = gitlab_project.my_group_my_project.id
+  branch                 = "develop"
+  push_access_level      = "developer"
+  merge_access_level     = "developer"
+  unprotect_access_level = "maintainer"
+  allow_force_push       = true
 }

--- a/internal/terraform/writer.go
+++ b/internal/terraform/writer.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -298,10 +299,12 @@ func WriteAll(resources *gitlab.Resources, dir string, mainGroup string, skipSet
 }
 
 func writeFile(path string, writeFn func(io.Writer) error) error {
-	f, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("creating file: %w", err)
+	var buf bytes.Buffer
+	if err := writeFn(&buf); err != nil {
+		return err
 	}
-	defer f.Close() //nolint:errcheck
-	return writeFn(f)
+	if buf.Len() == 0 {
+		return nil
+	}
+	return os.WriteFile(path, buf.Bytes(), 0o644)
 }


### PR DESCRIPTION
## Summary

- `gitlab_branch_protection` is now **skipped by default**; opt in with `--include branch_protection`. The upstream provider's `Read` does not populate `unprotect_access_level` into state on Free tier, causing perpetual ForceNew drift on every plan — not fixable in this tool, tracked separately.
- Skip projects/groups pending deletion (#23)
- Skip creating empty `.tf` files (e.g. `hooks.tf` when no hooks exist)
- Demote variable-skip log messages (masked/hidden/file) from warn to debug
- Clean up `tmp/` directory after scan completes
- Refactor: group premium-only branch protection attributes

Closes #23