### PR TITLE
feat: add gitlab_project_job_token_scopes drift detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ terraform/
 - ✅ GitLab Project Hooks ([`gitlab_project_hook`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_hook))
 - ✅ GitLab Group Hooks ([`gitlab_group_hook`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/group_hook)) *(requires Premium/Ultimate)*
 - 🚧 GitLab Branch Protection ([`gitlab_branch_protection`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/branch_protection)) — *skipped by default, opt in with `--include branch_protection`* **
+- ✅ GitLab Project Job Token Scopes ([`gitlab_project_job_token_scopes`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_job_token_scopes))
 - 🚧 More resources coming soon
 
 > **\* CI/CD Variable Filtering:** Masked variables and file-type variables are automatically skipped.

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -26,6 +26,7 @@ type Resources struct {
 	ProjectVariables  ProjectVariables
 	GroupVariables    GroupVariables
 	ProtectedBranches ProtectedBranches
+	JobTokenScopes    JobTokenScopes
 }
 
 func NewClientFromAPI(api *gl.Client, group string) *Client {
@@ -112,6 +113,15 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		slog.Info("fetched protected branches", "count", len(protectedBranches))
 	}
 
+	var jobTokenScopes JobTokenScopes
+	if !skipSet.Has("job_token_scopes") {
+		jobTokenScopes, err = c.ListJobTokenScopes(ctx, projects)
+		if err != nil {
+			return nil, fmt.Errorf("listing job token scopes: %w", err)
+		}
+		slog.Info("fetched job token scopes", "count", len(jobTokenScopes))
+	}
+
 	var projectHooks ProjectHooks
 	var groupHooks GroupHooks
 	if !skipSet.Has("hooks") {
@@ -140,5 +150,6 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		ProjectVariables:  projectVariables,
 		GroupVariables:    groupVariables,
 		ProtectedBranches: protectedBranches,
+		JobTokenScopes:    jobTokenScopes,
 	}, nil
 }

--- a/internal/gitlab/job_token_scopes.go
+++ b/internal/gitlab/job_token_scopes.go
@@ -1,0 +1,83 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+type JobTokenScope struct {
+	InboundEnabled  bool
+	AllowedProjects []*gl.Project
+	AllowedGroups   []*gl.Group
+}
+
+type JobTokenScopes = map[int64]*JobTokenScope
+
+func (c *Client) ListJobTokenScopes(ctx context.Context, projects []*gl.Project) (JobTokenScopes, error) {
+	result := make(JobTokenScopes, len(projects))
+
+	for _, p := range projects {
+		if p == nil {
+			continue
+		}
+		slog.Debug("fetching job token scopes", "project", p.PathWithNamespace)
+
+		settings, _, err := c.api.JobTokenScope.GetProjectJobTokenAccessSettings(p.ID, gl.WithContext(ctx))
+		if err != nil {
+			return nil, fmt.Errorf("getting job token access settings for project %d: %w", p.ID, err)
+		}
+
+		projectOpts := &gl.GetJobTokenInboundAllowListOptions{
+			ListOptions: gl.ListOptions{Page: 1, PerPage: 100},
+		}
+		var allowedProjects []*gl.Project
+		for {
+			page, resp, err := c.api.JobTokenScope.GetProjectJobTokenInboundAllowList(p.ID, projectOpts, gl.WithContext(ctx))
+			if err != nil {
+				return nil, fmt.Errorf("listing job token inbound allowlist projects for project %d: %w", p.ID, err)
+			}
+			allowedProjects = append(allowedProjects, page...)
+			if resp.NextPage == 0 {
+				break
+			}
+			projectOpts.Page = resp.NextPage
+		}
+
+		groupOpts := &gl.GetJobTokenAllowlistGroupsOptions{
+			ListOptions: gl.ListOptions{Page: 1, PerPage: 100},
+		}
+		var allowedGroups []*gl.Group
+		for {
+			page, resp, err := c.api.JobTokenScope.GetJobTokenAllowlistGroups(p.ID, groupOpts, gl.WithContext(ctx))
+			if err != nil {
+				return nil, fmt.Errorf("listing job token allowlist groups for project %d: %w", p.ID, err)
+			}
+			allowedGroups = append(allowedGroups, page...)
+			if resp.NextPage == 0 {
+				break
+			}
+			groupOpts.Page = resp.NextPage
+		}
+
+		// GitLab always includes the project itself in the inbound allowlist
+		// implicitly; filter it out so we don't emit redundant self-references.
+		filteredProjects := make([]*gl.Project, 0, len(allowedProjects))
+		for _, ap := range allowedProjects {
+			if ap.ID == p.ID {
+				continue
+			}
+			filteredProjects = append(filteredProjects, ap)
+		}
+
+		result[p.ID] = &JobTokenScope{
+			InboundEnabled:  settings.InboundEnabled,
+			AllowedProjects: filteredProjects,
+			AllowedGroups:   allowedGroups,
+		}
+	}
+
+	return result, nil
+}

--- a/internal/skip/skip.go
+++ b/internal/skip/skip.go
@@ -19,6 +19,7 @@ var ResourceTypes = []string{
 	"schedules",
 	"branch_protection",
 	"service_accounts",
+	"job_token_scopes",
 }
 
 // Groups map a single name to multiple resource types.

--- a/internal/terraform/import.go
+++ b/internal/terraform/import.go
@@ -207,6 +207,25 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 		}
 	}
 
+	if !skipSet.Has("job_token_scopes") {
+		for _, p := range resources.Projects {
+			if p == nil {
+				continue
+			}
+			if resources.JobTokenScopes[p.ID] == nil {
+				continue
+			}
+			name := projectResourceName(p)
+			key := "gitlab_project_job_token_scopes." + name
+			if !existingResources[key] {
+				cmds = append(cmds, ImportCommand{
+					Address: key,
+					ID:      fmt.Sprintf("%d", p.ID),
+				})
+			}
+		}
+	}
+
 	if !skipSet.Has("schedules") {
 		for _, p := range resources.Projects {
 			if p == nil {

--- a/internal/terraform/job_token_scopes.go
+++ b/internal/terraform/job_token_scopes.go
@@ -1,0 +1,84 @@
+package terraform
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/xMoelletschi/terraform-gitlab-drift/internal/gitlab"
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+func WriteJobTokenScopes(p *gl.Project, scope *gitlab.JobTokenScope, projectRefs projectRefMap, groupRefs groupRefMap, w io.Writer) error {
+	if scope == nil {
+		return nil
+	}
+	projName := projectResourceName(p)
+
+	if _, err := fmt.Fprintf(w, "resource \"gitlab_project_job_token_scopes\" \"%s\" {\n", projName); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "  project = gitlab_project.%s.id\n", projName); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "  enabled = %t\n", scope.InboundEnabled); err != nil {
+		return err
+	}
+
+	if len(scope.AllowedProjects) == 0 {
+		if _, err := fmt.Fprintln(w, "  target_project_ids = []"); err != nil {
+			return err
+		}
+	} else {
+		projects := make([]*gl.Project, len(scope.AllowedProjects))
+		copy(projects, scope.AllowedProjects)
+		sort.Slice(projects, func(i, j int) bool { return projects[i].ID < projects[j].ID })
+
+		if _, err := fmt.Fprintln(w, "  target_project_ids = ["); err != nil {
+			return err
+		}
+		for _, tp := range projects {
+			if name, ok := projectRefs[tp.ID]; ok && name != "" {
+				if _, err := fmt.Fprintf(w, "    gitlab_project.%s.id,\n", name); err != nil {
+					return err
+				}
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "    %d, # unmanaged: %s\n", tp.ID, tp.PathWithNamespace); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(w, "  ]"); err != nil {
+			return err
+		}
+	}
+
+	if len(scope.AllowedGroups) > 0 {
+		groups := make([]*gl.Group, len(scope.AllowedGroups))
+		copy(groups, scope.AllowedGroups)
+		sort.Slice(groups, func(i, j int) bool { return groups[i].ID < groups[j].ID })
+
+		if _, err := fmt.Fprintln(w, "  target_group_ids = ["); err != nil {
+			return err
+		}
+		for _, tg := range groups {
+			if name, ok := groupRefs[tg.ID]; ok && name != "" {
+				if _, err := fmt.Fprintf(w, "    gitlab_group.%s.id,\n", name); err != nil {
+					return err
+				}
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "    %d, # unmanaged: %s\n", tg.ID, tg.FullPath); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(w, "  ]"); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintln(w, "}"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/terraform/job_token_scopes_test.go
+++ b/internal/terraform/job_token_scopes_test.go
@@ -1,0 +1,128 @@
+package terraform
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/xMoelletschi/terraform-gitlab-drift/internal/gitlab"
+	gl "gitlab.com/gitlab-org/api/client-go"
+)
+
+func TestWriteJobTokenScopes_ManagedRefs(t *testing.T) {
+	project := &gl.Project{
+		ID:                1,
+		Path:              "my-project",
+		Namespace:         &gl.ProjectNamespace{FullPath: "my-group"},
+		PathWithNamespace: "my-group/my-project",
+	}
+
+	allowedProjects := []*gl.Project{
+		{ID: 10, Path: "foo", Namespace: &gl.ProjectNamespace{FullPath: "my-group"}, PathWithNamespace: "my-group/foo"},
+		{ID: 11, Path: "bar", Namespace: &gl.ProjectNamespace{FullPath: "my-group"}, PathWithNamespace: "my-group/bar"},
+	}
+	allowedGroups := []*gl.Group{
+		{ID: 20, Path: "other-group", FullPath: "other-group"},
+	}
+	scope := &gitlab.JobTokenScope{
+		InboundEnabled:  true,
+		AllowedProjects: allowedProjects,
+		AllowedGroups:   allowedGroups,
+	}
+
+	projectRefs := buildProjectRefMap(append([]*gl.Project{project}, allowedProjects...))
+	groupRefs := buildGroupRefMap(allowedGroups)
+
+	var buf bytes.Buffer
+	if err := WriteJobTokenScopes(project, scope, projectRefs, groupRefs, &buf); err != nil {
+		t.Fatalf("WriteJobTokenScopes error: %v", err)
+	}
+
+	compareGolden(t, "job_token_scopes_managed_refs.tf", buf.String())
+}
+
+func TestWriteJobTokenScopes_Mixed(t *testing.T) {
+	project := &gl.Project{
+		ID:                1,
+		Path:              "my-project",
+		Namespace:         &gl.ProjectNamespace{FullPath: "my-group"},
+		PathWithNamespace: "my-group/my-project",
+	}
+
+	inScopeProject := &gl.Project{
+		ID:                10,
+		Path:              "foo",
+		Namespace:         &gl.ProjectNamespace{FullPath: "my-group"},
+		PathWithNamespace: "my-group/foo",
+	}
+	externalProject := &gl.Project{
+		ID:                999,
+		Path:              "external",
+		PathWithNamespace: "other-org/external",
+	}
+	externalGroup := &gl.Group{
+		ID:       888,
+		Path:     "external-group",
+		FullPath: "other-org/external-group",
+	}
+	scope := &gitlab.JobTokenScope{
+		InboundEnabled:  true,
+		AllowedProjects: []*gl.Project{inScopeProject, externalProject},
+		AllowedGroups:   []*gl.Group{externalGroup},
+	}
+
+	projectRefs := buildProjectRefMap([]*gl.Project{project, inScopeProject})
+	groupRefs := buildGroupRefMap(nil)
+
+	var buf bytes.Buffer
+	if err := WriteJobTokenScopes(project, scope, projectRefs, groupRefs, &buf); err != nil {
+		t.Fatalf("WriteJobTokenScopes error: %v", err)
+	}
+
+	compareGolden(t, "job_token_scopes_mixed.tf", buf.String())
+}
+
+func TestWriteJobTokenScopes_EnabledOnly(t *testing.T) {
+	project := &gl.Project{
+		ID:                1,
+		Path:              "my-project",
+		Namespace:         &gl.ProjectNamespace{FullPath: "my-group"},
+		PathWithNamespace: "my-group/my-project",
+	}
+
+	scope := &gitlab.JobTokenScope{
+		InboundEnabled: true,
+	}
+
+	projectRefs := buildProjectRefMap([]*gl.Project{project})
+	groupRefs := buildGroupRefMap(nil)
+
+	var buf bytes.Buffer
+	if err := WriteJobTokenScopes(project, scope, projectRefs, groupRefs, &buf); err != nil {
+		t.Fatalf("WriteJobTokenScopes error: %v", err)
+	}
+
+	compareGolden(t, "job_token_scopes_enabled_only.tf", buf.String())
+}
+
+func TestWriteJobTokenScopes_Disabled(t *testing.T) {
+	project := &gl.Project{
+		ID:                1,
+		Path:              "my-project",
+		Namespace:         &gl.ProjectNamespace{FullPath: "my-group"},
+		PathWithNamespace: "my-group/my-project",
+	}
+
+	scope := &gitlab.JobTokenScope{
+		InboundEnabled: false,
+	}
+
+	projectRefs := buildProjectRefMap([]*gl.Project{project})
+	groupRefs := buildGroupRefMap(nil)
+
+	var buf bytes.Buffer
+	if err := WriteJobTokenScopes(project, scope, projectRefs, groupRefs, &buf); err != nil {
+		t.Fatalf("WriteJobTokenScopes error: %v", err)
+	}
+
+	compareGolden(t, "job_token_scopes_disabled.tf", buf.String())
+}

--- a/internal/terraform/refs.go
+++ b/internal/terraform/refs.go
@@ -23,6 +23,22 @@ func buildGroupRefMap(groups []*gl.Group) groupRefMap {
 	return refs
 }
 
+type projectRefMap map[int64]string
+
+func buildProjectRefMap(projects []*gl.Project) projectRefMap {
+	if len(projects) == 0 {
+		return nil
+	}
+	refs := make(projectRefMap, len(projects))
+	for _, p := range projects {
+		if p == nil || p.ID == 0 {
+			continue
+		}
+		refs[p.ID] = projectResourceName(p)
+	}
+	return refs
+}
+
 func setGroupIDAttribute(body *hclwrite.Body, attr string, id int64, refs groupRefMap) {
 	if id == 0 {
 		return

--- a/internal/terraform/testdata/job_token_scopes_disabled.tf
+++ b/internal/terraform/testdata/job_token_scopes_disabled.tf
@@ -1,0 +1,5 @@
+resource "gitlab_project_job_token_scopes" "my_group_my_project" {
+  project = gitlab_project.my_group_my_project.id
+  enabled = false
+  target_project_ids = []
+}

--- a/internal/terraform/testdata/job_token_scopes_enabled_only.tf
+++ b/internal/terraform/testdata/job_token_scopes_enabled_only.tf
@@ -1,0 +1,5 @@
+resource "gitlab_project_job_token_scopes" "my_group_my_project" {
+  project = gitlab_project.my_group_my_project.id
+  enabled = true
+  target_project_ids = []
+}

--- a/internal/terraform/testdata/job_token_scopes_managed_refs.tf
+++ b/internal/terraform/testdata/job_token_scopes_managed_refs.tf
@@ -1,0 +1,11 @@
+resource "gitlab_project_job_token_scopes" "my_group_my_project" {
+  project = gitlab_project.my_group_my_project.id
+  enabled = true
+  target_project_ids = [
+    gitlab_project.my_group_foo.id,
+    gitlab_project.my_group_bar.id,
+  ]
+  target_group_ids = [
+    gitlab_group.other_group.id,
+  ]
+}

--- a/internal/terraform/testdata/job_token_scopes_mixed.tf
+++ b/internal/terraform/testdata/job_token_scopes_mixed.tf
@@ -1,0 +1,11 @@
+resource "gitlab_project_job_token_scopes" "my_group_my_project" {
+  project = gitlab_project.my_group_my_project.id
+  enabled = true
+  target_project_ids = [
+    gitlab_project.my_group_foo.id,
+    999, # unmanaged: other-org/external
+  ]
+  target_group_ids = [
+    888, # unmanaged: other-org/external-group
+  ]
+}

--- a/internal/terraform/writer.go
+++ b/internal/terraform/writer.go
@@ -22,6 +22,7 @@ func WriteAll(resources *gitlab.Resources, dir string, mainGroup string, skipSet
 	var errs []error
 
 	groupRefs := buildGroupRefMap(resources.Groups)
+	projectRefs := buildProjectRefMap(resources.Projects)
 
 	groupsByPath := make(map[string]*gl.Group)
 	for _, g := range resources.Groups {
@@ -284,6 +285,13 @@ func WriteAll(resources *gitlab.Resources, dir string, mainGroup string, skipSet
 					if !skipSet.Has("labels") && len(resources.ProjectLabels[p.ID]) > 0 {
 						if err := WriteProjectLabelResource(p, w); err != nil {
 							return err
+						}
+					}
+					if !skipSet.Has("job_token_scopes") {
+						if scope := resources.JobTokenScopes[p.ID]; scope != nil {
+							if err := WriteJobTokenScopes(p, scope, projectRefs, groupRefs, w); err != nil {
+								return err
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## Summary

Adds drift detection for the per-project CI/CD job token inbound allowlist (`gitlab_project_job_token_scopes`). Tracks which other projects and groups may use a project's `CI_JOB_TOKEN` — security-relevant config that's commonly changed via UI.

Verified locally: \`terraform import\` + \`terraform plan\` produced no drift after the scan.

## Behavior

- One resource block per project, embedded in `{namespace}.tf` next to the project (analog to `gitlab_project_share_group`)
- Target project/group IDs rendered as Terraform refs (`gitlab_project.foo.id`) when the target is in scan scope; otherwise as literal int with `# unmanaged: <path>` comment
- Self-filter: project's own ID is removed from the inbound allowlist (GitLab includes it implicitly)
- `target_project_ids` is **always emitted** (empty list when no extras) so Terraform manages it authoritatively → manual UI additions show up as drift without re-import roundtrip
- `target_group_ids` is only emitted when non-empty
- `enabled = false` always emitted because it's a security loosening (disables allowlist enforcement entirely)

## Files

- New fetcher: `internal/gitlab/job_token_scopes.go`
- New writer: `internal/terraform/job_token_scopes.go`
- New helper: `buildProjectRefMap` in `internal/terraform/refs.go` (mirrors `buildGroupRefMap`)
- Wired into `client.go` (FetchAll), `writer.go` (per-namespace loop), `import.go` (import commands), `skip/skip.go` (`job_token_scopes` skip key)
- 4 golden tests covering: refs, mixed managed/unmanaged, default state, disabled

## Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] Build + vet clean
- [x] Smoke test (`--skip job_token_scopes` filters, unknown skip warns)
- [x] End-to-end: `terraform import` + `terraform plan` clean on real GitLab instance
- [ ] CI green