### PR TITLE
fix(job_token_scopes): run output through hclwrite.Format

### DIFF
--- a/internal/terraform/job_token_scopes.go
+++ b/internal/terraform/job_token_scopes.go
@@ -1,10 +1,12 @@
 package terraform
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"sort"
 
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/xMoelletschi/terraform-gitlab-drift/internal/gitlab"
 	gl "gitlab.com/gitlab-org/api/client-go"
 )
@@ -15,42 +17,28 @@ func WriteJobTokenScopes(p *gl.Project, scope *gitlab.JobTokenScope, projectRefs
 	}
 	projName := projectResourceName(p)
 
-	if _, err := fmt.Fprintf(w, "resource \"gitlab_project_job_token_scopes\" \"%s\" {\n", projName); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "  project = gitlab_project.%s.id\n", projName); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "  enabled = %t\n", scope.InboundEnabled); err != nil {
-		return err
-	}
+	var buf bytes.Buffer
+
+	fmt.Fprintf(&buf, "resource \"gitlab_project_job_token_scopes\" \"%s\" {\n", projName)
+	fmt.Fprintf(&buf, "  project = gitlab_project.%s.id\n", projName)
+	fmt.Fprintf(&buf, "  enabled = %t\n", scope.InboundEnabled)
 
 	if len(scope.AllowedProjects) == 0 {
-		if _, err := fmt.Fprintln(w, "  target_project_ids = []"); err != nil {
-			return err
-		}
+		fmt.Fprintln(&buf, "  target_project_ids = []")
 	} else {
 		projects := make([]*gl.Project, len(scope.AllowedProjects))
 		copy(projects, scope.AllowedProjects)
 		sort.Slice(projects, func(i, j int) bool { return projects[i].ID < projects[j].ID })
 
-		if _, err := fmt.Fprintln(w, "  target_project_ids = ["); err != nil {
-			return err
-		}
+		fmt.Fprintln(&buf, "  target_project_ids = [")
 		for _, tp := range projects {
 			if name, ok := projectRefs[tp.ID]; ok && name != "" {
-				if _, err := fmt.Fprintf(w, "    gitlab_project.%s.id,\n", name); err != nil {
-					return err
-				}
+				fmt.Fprintf(&buf, "    gitlab_project.%s.id,\n", name)
 				continue
 			}
-			if _, err := fmt.Fprintf(w, "    %d, # unmanaged: %s\n", tp.ID, tp.PathWithNamespace); err != nil {
-				return err
-			}
+			fmt.Fprintf(&buf, "    %d, # unmanaged: %s\n", tp.ID, tp.PathWithNamespace)
 		}
-		if _, err := fmt.Fprintln(w, "  ]"); err != nil {
-			return err
-		}
+		fmt.Fprintln(&buf, "  ]")
 	}
 
 	if len(scope.AllowedGroups) > 0 {
@@ -58,27 +46,21 @@ func WriteJobTokenScopes(p *gl.Project, scope *gitlab.JobTokenScope, projectRefs
 		copy(groups, scope.AllowedGroups)
 		sort.Slice(groups, func(i, j int) bool { return groups[i].ID < groups[j].ID })
 
-		if _, err := fmt.Fprintln(w, "  target_group_ids = ["); err != nil {
-			return err
-		}
+		fmt.Fprintln(&buf, "  target_group_ids = [")
 		for _, tg := range groups {
 			if name, ok := groupRefs[tg.ID]; ok && name != "" {
-				if _, err := fmt.Fprintf(w, "    gitlab_group.%s.id,\n", name); err != nil {
-					return err
-				}
+				fmt.Fprintf(&buf, "    gitlab_group.%s.id,\n", name)
 				continue
 			}
-			if _, err := fmt.Fprintf(w, "    %d, # unmanaged: %s\n", tg.ID, tg.FullPath); err != nil {
-				return err
-			}
+			fmt.Fprintf(&buf, "    %d, # unmanaged: %s\n", tg.ID, tg.FullPath)
 		}
-		if _, err := fmt.Fprintln(w, "  ]"); err != nil {
-			return err
-		}
+		fmt.Fprintln(&buf, "  ]")
 	}
 
-	if _, err := fmt.Fprintln(w, "}"); err != nil {
-		return err
-	}
-	return nil
+	fmt.Fprintln(&buf, "}")
+
+	// Run through hclwrite.Format so output matches `terraform fmt` exactly
+	// (aligns the `=` columns) — otherwise every fmt run produces drift.
+	_, err := w.Write(hclwrite.Format(buf.Bytes()))
+	return err
 }

--- a/internal/terraform/testdata/job_token_scopes_disabled.tf
+++ b/internal/terraform/testdata/job_token_scopes_disabled.tf
@@ -1,5 +1,5 @@
 resource "gitlab_project_job_token_scopes" "my_group_my_project" {
-  project = gitlab_project.my_group_my_project.id
-  enabled = false
+  project            = gitlab_project.my_group_my_project.id
+  enabled            = false
   target_project_ids = []
 }

--- a/internal/terraform/testdata/job_token_scopes_enabled_only.tf
+++ b/internal/terraform/testdata/job_token_scopes_enabled_only.tf
@@ -1,5 +1,5 @@
 resource "gitlab_project_job_token_scopes" "my_group_my_project" {
-  project = gitlab_project.my_group_my_project.id
-  enabled = true
+  project            = gitlab_project.my_group_my_project.id
+  enabled            = true
   target_project_ids = []
 }


### PR DESCRIPTION
## Summary

Fixes perpetual cosmetic drift on `gitlab_project_job_token_scopes` blocks.

The writer emitted single-space `=` alignment, but `terraform fmt` aligns the `=` to the widest attribute. Every `terraform fmt` run produced a diff, and the next scan re-overwrote it with the unaligned version — endless ping-pong.

Fix: buffer the printf output and run it through `hclwrite.Format()` before writing. Output now matches what `terraform fmt` would produce.

## Test Plan

- [x] All goldens regenerated (`UPDATE_GOLDEN=1 go test ./internal/terraform -run TestWriteJobTokenScopes`)
- [x] `terraform fmt -check` on all 4 goldens → clean
- [x] `go test ./...` → green