### PR TITLE
fix(job_token_scopes): keep self in allowlist when extras present

### DIFF
--- a/internal/gitlab/job_token_scopes.go
+++ b/internal/gitlab/job_token_scopes.go
@@ -62,11 +62,29 @@ func (c *Client) ListJobTokenScopes(ctx context.Context, projects []*gl.Project)
 			groupOpts.Page = resp.NextPage
 		}
 
-		// GitLab can return duplicate entries in the allowlist; the provider's
-		// state stores a deduped Set, so we dedup here too to match.
+		// Mirror the provider's Read behavior so HCL matches state.
+		//
+		// The provider's getProjectCIJobScopes removes self with a `break`,
+		// stripping a single self entry from the raw API response before
+		// storing the rest in a Set (which dedups by ID). When the GitLab
+		// API returns self more than once (a known data quirk reachable e.g.
+		// by manual UI/API additions), one self instance survives the
+		// `break` and ends up in state — and the API rejects DELETE on self
+		// with 400 "Source project cannot be removed from the job token
+		// scope", so emitting self-less HCL makes apply fail.
+		//
+		// We replicate this: count self occurrences in the raw response, then
+		// dedup. If self appeared <= 1 times we strip it (matches state =
+		// without self). If >= 2 times we keep it (matches state = with
+		// self). We never POST self ourselves, so this never propagates the
+		// duplicate to projects that don't already have it.
+		selfCount := 0
 		seen := make(map[int64]bool, len(allowedProjects))
 		deduped := make([]*gl.Project, 0, len(allowedProjects))
 		for _, ap := range allowedProjects {
+			if ap.ID == p.ID {
+				selfCount++
+			}
 			if seen[ap.ID] {
 				continue
 			}
@@ -74,15 +92,18 @@ func (c *Client) ListJobTokenScopes(ctx context.Context, projects []*gl.Project)
 			deduped = append(deduped, ap)
 		}
 
-		// The provider's Read function stores target_project_ids = [] when the
-		// API allowlist contains only the source project itself; we mirror
-		// that so HCL matches state. When the allowlist has additional
-		// entries we must keep self in the list — the GitLab API rejects
-		// DELETE requests for the source project ("Source project cannot be
-		// removed from the job token scope"), so emitting self-less HCL
-		// causes apply to fail when the provider tries to reconcile.
 		allowed := deduped
-		if len(deduped) == 1 && deduped[0].ID == p.ID {
+		if selfCount <= 1 {
+			filtered := make([]*gl.Project, 0, len(deduped))
+			for _, ap := range deduped {
+				if ap.ID == p.ID {
+					continue
+				}
+				filtered = append(filtered, ap)
+			}
+			allowed = filtered
+		}
+		if len(allowed) == 0 {
 			allowed = nil
 		}
 


### PR DESCRIPTION
## Summary

Follow-up to #33. The previous fix kept self in the allowlist when there were extra projects, but missed the case where the GitLab API returns the source project as a duplicate entry.

## Root cause (verified empirically)

1. GitLab REST API **accepts** `POST .../allowlist?target_project_id=<self>` without validation — adding a project to its own inbound allowlist creates a duplicate entry alongside the implicit self.
2. GitLab REST API **rejects** `DELETE .../allowlist/<self>` with `400 - "Source project cannot be removed from the job token scope"` regardless of duplicates.
3. The terraform-provider-gitlab `getProjectCIJobScopes` filter removes self with a `break`, only stripping **one** self instance. When the API returns self >= 2 times, one survives → state has self.

Result: any project where someone ever POSTed self (manually or via an old script) is stuck with self in state. Our previous self-filter emitted HCL without self, provider tried DELETE on self at apply → 400.

## Fix

Count self occurrences in the raw API response and only strip self when it appeared `<= 1` times.

| API self count | Provider state target_project_ids | Tool emits | Match? |
|---|---|---|---|
| 0 (impossible, API always returns self) | — | — | — |
| 1 (normal) | `[]` (after `break`) | `[]` | ✓ |
| 2+ (duplicate-self quirk) | `[self, ...]` (one survives `break`) | `[self, ...]` | ✓ |

Crucially the tool never POSTs self itself, so this fix never propagates the duplicate-self quirk to projects that don't already have it.

## Verification

End-to-end on a project with API self count = 2:
- Before this fix: `terraform apply` failed with `400 - Source project cannot be removed from the job token scope`
- After this fix: `terraform plan` shows `No changes`

## Upstream

The duplicate-self condition is a GitLab REST API quirk (asymmetric POST/DELETE on self), not a provider bug strictly. The `break` in the provider's filter is a related minor bug — worth a separate upstream MR if anyone has time.

## Test Plan

- [x] `go test ./...` green
- [x] End-to-end verification against `xdeveloperic/docker` (had duplicate self in API)
- [x] End-to-end verification against `xdeveloperic/playground/thisisatest/testprojectinsidetest` (artificially duplicated for the test)