### PR TITLE
feat(tag_protection): add gitlab_tag_protection drift detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ terraform/
 ├── pipeline_schedules.tf   # generated: variable with project → pipeline schedules
 ├── hooks.tf                # generated: project and group webhooks
 ├── branch_protections.tf   # generated: project branch protection rules
+├── tag_protections.tf      # generated: project tag protection rules
 └── ...
 ```
 
@@ -112,6 +113,7 @@ terraform/
 - ✅ GitLab Project Hooks ([`gitlab_project_hook`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_hook))
 - ✅ GitLab Group Hooks ([`gitlab_group_hook`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/group_hook)) *(requires Premium/Ultimate)*
 - 🚧 GitLab Branch Protection ([`gitlab_branch_protection`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/branch_protection)) — *skipped by default, opt in with `--include branch_protection`* **
+- ✅ GitLab Tag Protection ([`gitlab_tag_protection`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/tag_protection)) ***
 - ✅ GitLab Project Job Token Scopes ([`gitlab_project_job_token_scopes`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_job_token_scopes))
 - 🚧 More resources coming soon
 
@@ -130,6 +132,10 @@ terraform/
 > When enabled, the `allowed_to_push`, `allowed_to_merge`, `allowed_to_unprotect`, `unprotect_access_level`, and `code_owner_approval_required` attributes
 > require a GitLab Premium/Ultimate instance. They are emitted by default but can be excluded with `--skip premium`. When skipped, only the free-tier
 > attributes (`push_access_level`, `merge_access_level`, `allow_force_push`) are generated.
+>
+> **\*\*\* Tag Protection:** The free-tier `create_access_level` is emitted by default. The granular `allowed_to_create` blocks (specific users/groups/deploy
+> keys) require a GitLab Premium/Ultimate instance and can be excluded with `--skip premium`. Unlike branch protection, tag protection has no Free-tier read bug
+> (the resource has no `unprotect`/`ForceNew` attribute), so it runs by default and can be turned off with `--skip tag_protection`.
 
 ## Contributing
 

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -26,6 +26,7 @@ type Resources struct {
 	ProjectVariables  ProjectVariables
 	GroupVariables    GroupVariables
 	ProtectedBranches ProtectedBranches
+	ProtectedTags     ProtectedTags
 	JobTokenScopes    JobTokenScopes
 }
 
@@ -113,6 +114,15 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		slog.Info("fetched protected branches", "count", len(protectedBranches))
 	}
 
+	var protectedTags ProtectedTags
+	if !skipSet.Has("tag_protection") {
+		protectedTags, err = c.ListProtectedTags(ctx, projects)
+		if err != nil {
+			return nil, fmt.Errorf("listing protected tags: %w", err)
+		}
+		slog.Info("fetched protected tags", "count", len(protectedTags))
+	}
+
 	var jobTokenScopes JobTokenScopes
 	if !skipSet.Has("job_token_scopes") {
 		jobTokenScopes, err = c.ListJobTokenScopes(ctx, projects)
@@ -150,6 +160,7 @@ func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, er
 		ProjectVariables:  projectVariables,
 		GroupVariables:    groupVariables,
 		ProtectedBranches: protectedBranches,
+		ProtectedTags:     protectedTags,
 		JobTokenScopes:    jobTokenScopes,
 	}, nil
 }

--- a/internal/gitlab/tag_protections.go
+++ b/internal/gitlab/tag_protections.go
@@ -1,0 +1,45 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// ProtectedTags maps project IDs to their protected tags.
+type ProtectedTags = map[int64][]*gl.ProtectedTag
+
+func (c *Client) ListProtectedTags(ctx context.Context, projects []*gl.Project) (ProtectedTags, error) {
+	result := make(ProtectedTags, len(projects))
+
+	for _, p := range projects {
+		if p == nil {
+			continue
+		}
+		slog.Debug("fetching protected tags", "project", p.PathWithNamespace)
+		opts := &gl.ListProtectedTagsOptions{
+			ListOptions: gl.ListOptions{
+				Page:    1,
+				PerPage: 100,
+			},
+		}
+		var tags []*gl.ProtectedTag
+		for {
+			page, resp, err := c.api.ProtectedTags.ListProtectedTags(p.ID, opts, gl.WithContext(ctx))
+			if err != nil {
+				return nil, fmt.Errorf("listing protected tags for project %d: %w", p.ID, err)
+			}
+			tags = append(tags, page...)
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+		if len(tags) > 0 {
+			result[p.ID] = tags
+		}
+	}
+	return result, nil
+}

--- a/internal/skip/skip.go
+++ b/internal/skip/skip.go
@@ -18,6 +18,7 @@ var ResourceTypes = []string{
 	"mr_approvals",
 	"schedules",
 	"branch_protection",
+	"tag_protection",
 	"service_accounts",
 	"job_token_scopes",
 }

--- a/internal/terraform/branch_protections.go
+++ b/internal/terraform/branch_protections.go
@@ -21,7 +21,9 @@ func branchProtectionResourceName(p *gl.Project, b *gl.ProtectedBranch) string {
 
 const adminAccessLevel gl.AccessLevelValue = 60
 
-func branchProtectionAccessLevel(level gl.AccessLevelValue) string {
+// protectionAccessLevel maps an access level to the string used by branch and
+// tag protection resources (push/merge/unprotect and create access levels).
+func protectionAccessLevel(level gl.AccessLevelValue) string {
 	switch level {
 	case gl.NoPermissions:
 		return "no one"
@@ -77,8 +79,8 @@ func WriteBranchProtections(p *gl.Project, branches []*gl.ProtectedBranch, premi
 		pushLevel := baseAccessLevel(b.PushAccessLevels)
 		mergeLevel := baseAccessLevel(b.MergeAccessLevels)
 
-		body.SetAttributeValue("push_access_level", cty.StringVal(branchProtectionAccessLevel(pushLevel)))
-		body.SetAttributeValue("merge_access_level", cty.StringVal(branchProtectionAccessLevel(mergeLevel)))
+		body.SetAttributeValue("push_access_level", cty.StringVal(protectionAccessLevel(pushLevel)))
+		body.SetAttributeValue("merge_access_level", cty.StringVal(protectionAccessLevel(mergeLevel)))
 
 		if b.AllowForcePush {
 			body.SetAttributeValue("allow_force_push", cty.True)
@@ -86,7 +88,7 @@ func WriteBranchProtections(p *gl.Project, branches []*gl.ProtectedBranch, premi
 
 		if premium {
 			unprotectLevel := baseAccessLevel(b.UnprotectAccessLevels)
-			body.SetAttributeValue("unprotect_access_level", cty.StringVal(branchProtectionAccessLevel(unprotectLevel)))
+			body.SetAttributeValue("unprotect_access_level", cty.StringVal(protectionAccessLevel(unprotectLevel)))
 
 			if b.CodeOwnerApprovalRequired {
 				body.SetAttributeValue("code_owner_approval_required", cty.True)

--- a/internal/terraform/import.go
+++ b/internal/terraform/import.go
@@ -173,6 +173,24 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 		}
 	}
 
+	if !skipSet.Has("tag_protection") {
+		for _, p := range resources.Projects {
+			if p == nil {
+				continue
+			}
+			for _, t := range resources.ProtectedTags[p.ID] {
+				name := tagProtectionResourceName(p, t)
+				key := "gitlab_tag_protection." + name
+				if !existingResources[key] {
+					cmds = append(cmds, ImportCommand{
+						Address: key,
+						ID:      fmt.Sprintf("%d:%s", p.ID, t.Name),
+					})
+				}
+			}
+		}
+	}
+
 	if !skipSet.Has("hooks") {
 		for _, g := range resources.Groups {
 			if g == nil {

--- a/internal/terraform/import.go
+++ b/internal/terraform/import.go
@@ -178,9 +178,10 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 			if p == nil {
 				continue
 			}
-			for _, t := range resources.ProtectedTags[p.ID] {
-				name := tagProtectionResourceName(p, t)
-				key := "gitlab_tag_protection." + name
+			tags := resources.ProtectedTags[p.ID]
+			names := tagProtectionResourceNames(p, tags)
+			for i, t := range tags {
+				key := "gitlab_tag_protection." + names[i]
 				if !existingResources[key] {
 					cmds = append(cmds, ImportCommand{
 						Address: key,

--- a/internal/terraform/tag_protections.go
+++ b/internal/terraform/tag_protections.go
@@ -1,0 +1,87 @@
+package terraform
+
+import (
+	"io"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+func normalizeTagName(s string) string {
+	return normalizeBranchName(s)
+}
+
+func tagProtectionResourceName(p *gl.Project, t *gl.ProtectedTag) string {
+	return projectResourceName(p) + "_" + normalizeTagName(t.Name)
+}
+
+func isBaseTagAccessLevel(l *gl.TagAccessDescription) bool {
+	return l.UserID == 0 && l.GroupID == 0 && l.DeployKeyID == 0
+}
+
+// baseTagAccessLevel returns the access level from the entry that represents
+// the overall create access level (no specific user/group/deploy key).
+func baseTagAccessLevel(levels []*gl.TagAccessDescription) gl.AccessLevelValue {
+	for _, l := range levels {
+		if isBaseTagAccessLevel(l) {
+			return l.AccessLevel
+		}
+	}
+	if len(levels) > 0 {
+		return levels[0].AccessLevel
+	}
+	return gl.MaintainerPermissions
+}
+
+func WriteTagProtections(p *gl.Project, tags []*gl.ProtectedTag, premium bool, w io.Writer) error {
+	f := hclwrite.NewEmptyFile()
+	rootBody := f.Body()
+	projName := projectResourceName(p)
+
+	for i, t := range tags {
+		if i > 0 {
+			rootBody.AppendNewline()
+		}
+		name := tagProtectionResourceName(p, t)
+		block := rootBody.AppendNewBlock("resource", []string{"gitlab_tag_protection", name})
+		body := block.Body()
+
+		body.SetAttributeTraversal("project", hcl.Traversal{
+			hcl.TraverseRoot{Name: "gitlab_project"},
+			hcl.TraverseAttr{Name: projName},
+			hcl.TraverseAttr{Name: "id"},
+		})
+		body.SetAttributeValue("tag", cty.StringVal(t.Name))
+
+		createLevel := baseTagAccessLevel(t.CreateAccessLevels)
+		body.SetAttributeValue("create_access_level", cty.StringVal(branchProtectionAccessLevel(createLevel)))
+
+		if premium {
+			writeTagAccessBlocks(body, "allowed_to_create", t.CreateAccessLevels)
+		}
+	}
+
+	_, err := w.Write(f.Bytes())
+	return err
+}
+
+func writeTagAccessBlocks(body *hclwrite.Body, blockName string, levels []*gl.TagAccessDescription) {
+	for _, l := range levels {
+		if isBaseTagAccessLevel(l) {
+			continue
+		}
+		nested := body.AppendNewBlock(blockName, nil)
+		nb := nested.Body()
+		if l.UserID != 0 {
+			nb.SetAttributeValue("user_id", cty.NumberIntVal(l.UserID))
+		}
+		if l.GroupID != 0 {
+			nb.SetAttributeValue("group_id", cty.NumberIntVal(l.GroupID))
+		}
+		if l.DeployKeyID != 0 {
+			nb.SetAttributeValue("deploy_key_id", cty.NumberIntVal(l.DeployKeyID))
+		}
+	}
+}

--- a/internal/terraform/tag_protections.go
+++ b/internal/terraform/tag_protections.go
@@ -52,7 +52,7 @@ func WriteTagProtections(p *gl.Project, tags []*gl.ProtectedTag, premium bool, w
 		body.SetAttributeValue("tag", cty.StringVal(t.Name))
 
 		createLevel := baseTagAccessLevel(t.CreateAccessLevels)
-		body.SetAttributeValue("create_access_level", cty.StringVal(branchProtectionAccessLevel(createLevel)))
+		body.SetAttributeValue("create_access_level", cty.StringVal(protectionAccessLevel(createLevel)))
 
 		if premium {
 			writeTagAccessBlocks(body, "allowed_to_create", t.CreateAccessLevels)

--- a/internal/terraform/tag_protections.go
+++ b/internal/terraform/tag_protections.go
@@ -9,12 +9,8 @@ import (
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func normalizeTagName(s string) string {
-	return normalizeBranchName(s)
-}
-
 func tagProtectionResourceName(p *gl.Project, t *gl.ProtectedTag) string {
-	return projectResourceName(p) + "_" + normalizeTagName(t.Name)
+	return projectResourceName(p) + "_" + normalizeBranchName(t.Name)
 }
 
 func isBaseTagAccessLevel(l *gl.TagAccessDescription) bool {

--- a/internal/terraform/tag_protections.go
+++ b/internal/terraform/tag_protections.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/hashicorp/hcl/v2"
@@ -11,6 +12,27 @@ import (
 
 func tagProtectionResourceName(p *gl.Project, t *gl.ProtectedTag) string {
 	return projectResourceName(p) + "_" + normalizeBranchName(t.Name)
+}
+
+// tagProtectionResourceNames returns deterministic, collision-free terraform
+// resource names for one project's protected tags. Distinct tag names can
+// normalize to the same label (e.g. "v1.0" and "v1-0" both become "v1_0"); the
+// second and later collisions get a numeric suffix so every block stays unique.
+// The writer and the import generator must call this with the same tag slice so
+// the names they emit agree.
+func tagProtectionResourceNames(p *gl.Project, tags []*gl.ProtectedTag) []string {
+	names := make([]string, len(tags))
+	used := make(map[string]bool, len(tags))
+	for i, t := range tags {
+		base := tagProtectionResourceName(p, t)
+		name := base
+		for n := 1; used[name]; n++ {
+			name = fmt.Sprintf("%s_%d", base, n)
+		}
+		used[name] = true
+		names[i] = name
+	}
+	return names
 }
 
 func isBaseTagAccessLevel(l *gl.TagAccessDescription) bool {
@@ -35,13 +57,13 @@ func WriteTagProtections(p *gl.Project, tags []*gl.ProtectedTag, premium bool, w
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 	projName := projectResourceName(p)
+	names := tagProtectionResourceNames(p, tags)
 
 	for i, t := range tags {
 		if i > 0 {
 			rootBody.AppendNewline()
 		}
-		name := tagProtectionResourceName(p, t)
-		block := rootBody.AppendNewBlock("resource", []string{"gitlab_tag_protection", name})
+		block := rootBody.AppendNewBlock("resource", []string{"gitlab_tag_protection", names[i]})
 		body := block.Body()
 
 		body.SetAttributeTraversal("project", hcl.Traversal{

--- a/internal/terraform/tag_protections_test.go
+++ b/internal/terraform/tag_protections_test.go
@@ -33,6 +33,33 @@ func TestTagProtectionResourceNameWildcard(t *testing.T) {
 	}
 }
 
+func TestTagProtectionResourceNamesCollision(t *testing.T) {
+	project := &gl.Project{
+		Path:      "my-project",
+		Namespace: &gl.ProjectNamespace{FullPath: "my-group"},
+	}
+	// All three tag names normalize to the same base label and must stay unique.
+	tags := []*gl.ProtectedTag{
+		{Name: "v1.0"},
+		{Name: "v1-0"},
+		{Name: "v1_0"},
+	}
+	got := tagProtectionResourceNames(project, tags)
+	want := []string{
+		"my_group_my_project_v1_0",
+		"my_group_my_project_v1_0_1",
+		"my_group_my_project_v1_0_2",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d names, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("names[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestWriteTagProtections_Free(t *testing.T) {
 	project := &gl.Project{
 		ID:                1,

--- a/internal/terraform/tag_protections_test.go
+++ b/internal/terraform/tag_protections_test.go
@@ -1,0 +1,99 @@
+package terraform
+
+import (
+	"bytes"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+func TestTagProtectionResourceName(t *testing.T) {
+	project := &gl.Project{
+		Path:      "my-project",
+		Namespace: &gl.ProjectNamespace{FullPath: "my-group"},
+	}
+	tag := &gl.ProtectedTag{Name: "v1.0.0"}
+	got := tagProtectionResourceName(project, tag)
+	want := "my_group_my_project_v1_0_0"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestTagProtectionResourceNameWildcard(t *testing.T) {
+	project := &gl.Project{
+		Path:      "my-project",
+		Namespace: &gl.ProjectNamespace{FullPath: "my-group"},
+	}
+	tag := &gl.ProtectedTag{Name: "v*"}
+	got := tagProtectionResourceName(project, tag)
+	want := "my_group_my_project_vwildcard"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteTagProtections_Free(t *testing.T) {
+	project := &gl.Project{
+		ID:                1,
+		Path:              "my-project",
+		Namespace:         &gl.ProjectNamespace{FullPath: "my-group"},
+		PathWithNamespace: "my-group/my-project",
+	}
+
+	tags := []*gl.ProtectedTag{
+		{
+			Name: "v1.0.0",
+			CreateAccessLevels: []*gl.TagAccessDescription{
+				{AccessLevel: gl.MaintainerPermissions},
+			},
+		},
+		{
+			Name: "release-*",
+			CreateAccessLevels: []*gl.TagAccessDescription{
+				{AccessLevel: gl.DeveloperPermissions},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteTagProtections(project, tags, false, &buf); err != nil {
+		t.Fatalf("WriteTagProtections error: %v", err)
+	}
+
+	compareGolden(t, "tag_protections_free.tf", buf.String())
+}
+
+func TestWriteTagProtections_Premium(t *testing.T) {
+	project := &gl.Project{
+		ID:                1,
+		Path:              "my-project",
+		Namespace:         &gl.ProjectNamespace{FullPath: "my-group"},
+		PathWithNamespace: "my-group/my-project",
+	}
+
+	tags := []*gl.ProtectedTag{
+		{
+			Name: "v1.0.0",
+			CreateAccessLevels: []*gl.TagAccessDescription{
+				{AccessLevel: gl.MaintainerPermissions},
+				{AccessLevel: gl.DeveloperPermissions, UserID: 5},
+				{AccessLevel: gl.DeveloperPermissions, UserID: 10},
+			},
+		},
+		{
+			Name: "release-*",
+			CreateAccessLevels: []*gl.TagAccessDescription{
+				{AccessLevel: gl.DeveloperPermissions},
+				{AccessLevel: gl.DeveloperPermissions, GroupID: 42},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteTagProtections(project, tags, true, &buf); err != nil {
+		t.Fatalf("WriteTagProtections error: %v", err)
+	}
+
+	compareGolden(t, "tag_protections_premium.tf", buf.String())
+}

--- a/internal/terraform/testdata/tag_protections_free.tf
+++ b/internal/terraform/testdata/tag_protections_free.tf
@@ -1,0 +1,11 @@
+resource "gitlab_tag_protection" "my_group_my_project_v1_0_0" {
+  project             = gitlab_project.my_group_my_project.id
+  tag                 = "v1.0.0"
+  create_access_level = "maintainer"
+}
+
+resource "gitlab_tag_protection" "my_group_my_project_release_wildcard" {
+  project             = gitlab_project.my_group_my_project.id
+  tag                 = "release-*"
+  create_access_level = "developer"
+}

--- a/internal/terraform/testdata/tag_protections_premium.tf
+++ b/internal/terraform/testdata/tag_protections_premium.tf
@@ -1,0 +1,20 @@
+resource "gitlab_tag_protection" "my_group_my_project_v1_0_0" {
+  project             = gitlab_project.my_group_my_project.id
+  tag                 = "v1.0.0"
+  create_access_level = "maintainer"
+  allowed_to_create {
+    user_id = 5
+  }
+  allowed_to_create {
+    user_id = 10
+  }
+}
+
+resource "gitlab_tag_protection" "my_group_my_project_release_wildcard" {
+  project             = gitlab_project.my_group_my_project.id
+  tag                 = "release-*"
+  create_access_level = "developer"
+  allowed_to_create {
+    group_id = 42
+  }
+}

--- a/internal/terraform/writer.go
+++ b/internal/terraform/writer.go
@@ -197,6 +197,33 @@ func WriteAll(resources *gitlab.Resources, dir string, mainGroup string, skipSet
 		}
 	}
 
+	// Write tag_protections.tf with individual resource blocks
+	if !skipSet.Has("tag_protection") {
+		premium := !skipSet.Has("premium")
+		if err := writeFile(filepath.Join(dir, "tag_protections.tf"), func(w io.Writer) error {
+			first := true
+			for _, p := range resources.Projects {
+				if p == nil {
+					continue
+				}
+				if tags := resources.ProtectedTags[p.ID]; len(tags) > 0 {
+					if !first {
+						if _, err := w.Write([]byte("\n")); err != nil {
+							return err
+						}
+					}
+					if err := WriteTagProtections(p, tags, premium, w); err != nil {
+						return err
+					}
+					first = false
+				}
+			}
+			return nil
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("tag_protections.tf: %w", err))
+		}
+	}
+
 	// Write hooks.tf with individual resource blocks
 	if !skipSet.Has("hooks") {
 		if err := writeFile(filepath.Join(dir, "hooks.tf"), func(w io.Writer) error {


### PR DESCRIPTION
## What

Adds drift detection for `gitlab_tag_protection`, the direct pendant of the existing `gitlab_branch_protection` support. For every scanned project it emits one `resource "gitlab_tag_protection"` block per protected tag into `tag_protections.tf`, plus a matching `terraform import` command (id `project_id:tag`).

## Tier behaviour

- **Free:** `create_access_level` is always emitted.
- **Premium:** granular `allowed_to_create` blocks (`user_id` / `group_id` / `deploy_key_id`) are emitted, gated by `--skip premium` — same mechanism as `branch_protection`'s premium attributes.

## Runs by default (unlike `branch_protection`)

`tag_protection` is **not** added to `DefaultSkipped`. `branch_protection` is default-skipped because the provider's Read does not populate `unprotect_access_level` on Free tier (a `ForceNew` attribute → perpetual `terraform plan` drift). `gitlab_tag_protection` has no such attribute — it is just `tag` + `create_access_level` (+ premium `allowed_to_create`) — so no Free-tier read bug exists. It can be turned off with `--skip tag_protection`.

## Implementation

- `internal/gitlab/tag_protections.go` — fetch (`ListProtectedTags`)
- `internal/terraform/tag_protections.go` — writer (`WriteTagProtections`)
- Wired into `client.go`, `writer.go`, `import.go`, `skip.go` (mirrors the `branch_protection` extension points)
- Renamed the shared access-level mapper `branchProtectionAccessLevel` → `protectionAccessLevel` (now used by both branch and tag protection)
- Resource names are de-duplicated when distinct tag names normalize to the same label (e.g. `v1.0` / `v1-0` both → `v1_0`)
- Golden tests (Free + Premium) + a name-collision test + README

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all green.
- **Validated live against a Free GitLab instance:** generated `tag_protections.tf` for two `v*`-protected projects, ran the generated `terraform import`, and the subsequent `terraform plan` reported **"No changes"** — confirming no perpetual drift on Free tier.
