### PR TITLE
Foundation hardening — stabilize + refactor (Phase 1–2)

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/xMoelletschi/terraform-gitlab-drift/internal/gitlab"
@@ -26,6 +27,7 @@ var (
 	targetRepo       string
 	mrDestPath       string
 	mrBranch         string
+	scanTimeout      time.Duration
 )
 
 var scanCmd = &cobra.Command{
@@ -44,10 +46,21 @@ func init() {
 	scanCmd.Flags().StringVar(&targetRepo, "target-repo", "", "GitLab project path or ID for the MR (default: detected from git remote in --terraform-dir)")
 	scanCmd.Flags().StringVar(&mrDestPath, "mr-dest-path", "", "Path within target repo where .tf files go (default: root)")
 	scanCmd.Flags().StringVar(&mrBranch, "mr-branch", "drift/backtrack", "Branch name for the drift MR")
+	scanCmd.Flags().DurationVar(&scanTimeout, "timeout", 0, "Maximum total scan duration (e.g. 30m); 0 disables the timeout")
+}
+
+// withTimeout bounds ctx to d. A non-positive d returns ctx unchanged with a
+// no-op cancel, so the default (0) preserves the previous unbounded behavior.
+func withTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+	if d <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, d)
 }
 
 func runScan(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
+	ctx, cancel := withTimeout(cmd.Context(), scanTimeout)
+	defer cancel()
 	token := gitlabToken
 	if token == "" {
 		token = os.Getenv("GITLAB_TOKEN")

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -24,10 +24,12 @@ var (
 	showDiff         bool
 	skipResources    []string
 	includeResources []string
-	targetRepo       string
-	mrDestPath       string
-	mrBranch         string
-	scanTimeout      time.Duration
+	targetRepo          string
+	mrDestPath          string
+	mrBranch            string
+	scanTimeout         time.Duration
+	showPendingDeletion bool
+	hideArchived        bool
 )
 
 var scanCmd = &cobra.Command{
@@ -47,6 +49,8 @@ func init() {
 	scanCmd.Flags().StringVar(&mrDestPath, "mr-dest-path", "", "Path within target repo where .tf files go (default: root)")
 	scanCmd.Flags().StringVar(&mrBranch, "mr-branch", "drift/backtrack", "Branch name for the drift MR")
 	scanCmd.Flags().DurationVar(&scanTimeout, "timeout", 0, "Maximum total scan duration (e.g. 30m); 0 disables the timeout")
+	scanCmd.Flags().BoolVar(&showPendingDeletion, "show-pending-deletion", false, "Include groups/projects in the deletion grace period (hidden by default)")
+	scanCmd.Flags().BoolVar(&hideArchived, "hide-archived", false, "Skip archived projects (shown by default)")
 }
 
 // withTimeout bounds ctx to d. A non-positive d returns ctx unchanged with a
@@ -108,8 +112,13 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 	slog.Debug("fetching resources from GitLab API")
 
+	filterCfg := gitlab.FilterConfig{
+		ShowPendingDeletion: showPendingDeletion,
+		HideArchived:        hideArchived,
+	}
+
 	// Fetch resources from GitLab API
-	resources, err := client.FetchAll(ctx, skipSet)
+	resources, err := client.FetchAll(ctx, skipSet, filterCfg)
 	if err != nil {
 		return fmt.Errorf("fetching resources: %w", err)
 	}

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWithTimeout_ZeroMeansNoDeadline(t *testing.T) {
+	ctx, cancel := withTimeout(context.Background(), 0)
+	defer cancel()
+	if _, ok := ctx.Deadline(); ok {
+		t.Error("expected no deadline for zero timeout")
+	}
+}
+
+func TestWithTimeout_PositiveSetsDeadline(t *testing.T) {
+	ctx, cancel := withTimeout(context.Background(), time.Minute)
+	defer cancel()
+	if _, ok := ctx.Deadline(); !ok {
+		t.Error("expected a deadline for a positive timeout")
+	}
+}

--- a/internal/gitlab/branch_protections.go
+++ b/internal/gitlab/branch_protections.go
@@ -25,20 +25,11 @@ func (c *Client) ListProtectedBranches(ctx context.Context, projects []*gl.Proje
 				PerPage: 100,
 			},
 		}
-		var branches []*gl.ProtectedBranch
-		for {
-			page, resp, err := c.api.ProtectedBranches.ListProtectedBranches(p.ID, opts, gl.WithContext(ctx))
-			if err != nil {
-				if skipInaccessible(err, "protected branches", p.PathWithNamespace) {
-					break
-				}
-				return nil, fmt.Errorf("listing protected branches for project %d: %w", p.ID, err)
-			}
-			branches = append(branches, page...)
-			if resp.NextPage == 0 {
-				break
-			}
-			opts.Page = resp.NextPage
+		branches, err := paginate(&opts.ListOptions, "protected branches", p.PathWithNamespace, func() ([]*gl.ProtectedBranch, *gl.Response, error) {
+			return c.api.ProtectedBranches.ListProtectedBranches(p.ID, opts, gl.WithContext(ctx))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing protected branches for project %d: %w", p.ID, err)
 		}
 		if len(branches) > 0 {
 			result[p.ID] = branches

--- a/internal/gitlab/branch_protections.go
+++ b/internal/gitlab/branch_protections.go
@@ -29,6 +29,9 @@ func (c *Client) ListProtectedBranches(ctx context.Context, projects []*gl.Proje
 		for {
 			page, resp, err := c.api.ProtectedBranches.ListProtectedBranches(p.ID, opts, gl.WithContext(ctx))
 			if err != nil {
+				if skipInaccessible(err, "protected branches", p.PathWithNamespace) {
+					break
+				}
 				return nil, fmt.Errorf("listing protected branches for project %d: %w", p.ID, err)
 			}
 			branches = append(branches, page...)

--- a/internal/gitlab/branch_protections_test.go
+++ b/internal/gitlab/branch_protections_test.go
@@ -1,0 +1,42 @@
+package gitlab
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+	gitlabtesting "gitlab.com/gitlab-org/api/client-go/v2/testing"
+	"go.uber.org/mock/gomock"
+)
+
+func TestListProtectedBranches_SkipsInaccessibleProject(t *testing.T) {
+	tc := gitlabtesting.NewTestClient(t)
+	c := NewClientFromAPI(tc.Client, "mygroup")
+
+	gomock.InOrder(
+		// First project is forbidden — must be skipped, not abort the whole scan.
+		tc.MockProtectedBranches.EXPECT().
+			ListProtectedBranches(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, nil, &gl.ErrorResponse{StatusCode: http.StatusForbidden}),
+		// Second project must still be fetched.
+		tc.MockProtectedBranches.EXPECT().
+			ListProtectedBranches(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]*gl.ProtectedBranch{{Name: "main"}}, &gl.Response{}, nil),
+	)
+
+	projects := []*gl.Project{
+		{ID: 1, PathWithNamespace: "mygroup/forbidden"},
+		{ID: 2, PathWithNamespace: "mygroup/ok"},
+	}
+	result, err := c.ListProtectedBranches(context.Background(), projects)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := result[1]; ok {
+		t.Errorf("forbidden project should have no entry, got %v", result[1])
+	}
+	if len(result[2]) != 1 || result[2][0].Name != "main" {
+		t.Errorf("expected project 2 to have branch 'main', got %v", result[2])
+	}
+}

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -42,14 +42,14 @@ func NewClient(token, baseURL, group string) (*Client, error) {
 	return &Client{api: client, group: group}, nil
 }
 
-func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set) (*Resources, error) {
-	groups, err := c.ListGroups(ctx)
+func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set, cfg FilterConfig) (*Resources, error) {
+	groups, err := c.ListGroups(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("listing groups: %w", err)
 	}
 	slog.Info("fetched groups", "count", len(groups))
 
-	projects, err := c.ListProjects(ctx)
+	projects, err := c.ListProjects(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("listing projects: %w", err)
 	}

--- a/internal/gitlab/errors.go
+++ b/internal/gitlab/errors.go
@@ -1,0 +1,26 @@
+package gitlab
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// skipInaccessible reports whether err is a GitLab API error that means the
+// resource is inaccessible to us (403 Forbidden) or no longer exists (404 Not
+// Found). Such an error should skip the affected resource rather than abort the
+// whole scan — a single restricted, archived, or just-deleted project or
+// subgroup must not fail an entire instance scan. When it returns true it logs a
+// path-named warning describing what was skipped.
+func skipInaccessible(err error, resource, path string) bool {
+	var errResp *gl.ErrorResponse
+	if errors.As(err, &errResp) &&
+		(errResp.HasStatusCode(http.StatusForbidden) || errResp.HasStatusCode(http.StatusNotFound)) {
+		slog.Warn("skipping inaccessible resource",
+			"resource", resource, "path", path, "status", errResp.StatusCode)
+		return true
+	}
+	return false
+}

--- a/internal/gitlab/errors_test.go
+++ b/internal/gitlab/errors_test.go
@@ -1,0 +1,31 @@
+package gitlab
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+func TestSkipInaccessible(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"forbidden", &gl.ErrorResponse{StatusCode: http.StatusForbidden}, true},
+		{"not found", &gl.ErrorResponse{StatusCode: http.StatusNotFound}, true},
+		{"not found sentinel", gl.ErrNotFound, true},
+		{"server error", &gl.ErrorResponse{StatusCode: http.StatusInternalServerError}, false},
+		{"generic error", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := skipInaccessible(tt.err, "test resource", "group/project")
+			if got != tt.want {
+				t.Errorf("skipInaccessible(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/gitlab/filter.go
+++ b/internal/gitlab/filter.go
@@ -1,0 +1,48 @@
+package gitlab
+
+import (
+	"log/slog"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// FilterConfig controls which groups and projects a scan includes, based on
+// their lifecycle state. It is populated from CLI flags today; keeping it as a
+// single struct means a future config file can populate the same fields without
+// touching the call sites.
+type FilterConfig struct {
+	// ShowPendingDeletion includes groups and projects that are in the deletion
+	// grace period (MarkedForDeletionOn). They are hidden by default.
+	ShowPendingDeletion bool
+	// HideArchived excludes archived projects. They are shown by default.
+	// (Groups have no archived state in the GitLab API.)
+	HideArchived bool
+}
+
+func filterGroups(groups []*gl.Group, cfg FilterConfig) []*gl.Group {
+	filtered := make([]*gl.Group, 0, len(groups))
+	for _, g := range groups {
+		if !cfg.ShowPendingDeletion && g.MarkedForDeletionOn != nil {
+			slog.Debug("skipping group pending deletion", "group", g.FullPath)
+			continue
+		}
+		filtered = append(filtered, g)
+	}
+	return filtered
+}
+
+func filterProjects(projects []*gl.Project, cfg FilterConfig) []*gl.Project {
+	filtered := make([]*gl.Project, 0, len(projects))
+	for _, p := range projects {
+		if !cfg.ShowPendingDeletion && p.MarkedForDeletionOn != nil {
+			slog.Debug("skipping project pending deletion", "project", p.PathWithNamespace)
+			continue
+		}
+		if cfg.HideArchived && p.Archived {
+			slog.Debug("skipping archived project", "project", p.PathWithNamespace)
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	return filtered
+}

--- a/internal/gitlab/group_members.go
+++ b/internal/gitlab/group_members.go
@@ -29,6 +29,9 @@ func (c *Client) ListGroupMembers(ctx context.Context, groups []*gl.Group) (Grou
 		for {
 			page, resp, err := c.api.Groups.ListGroupMembers(g.ID, opts, gl.WithContext(ctx))
 			if err != nil {
+				if skipInaccessible(err, "group members", g.FullPath) {
+					break
+				}
 				return nil, fmt.Errorf("listing members for group %d: %w", g.ID, err)
 			}
 			members = append(members, page...)

--- a/internal/gitlab/group_members.go
+++ b/internal/gitlab/group_members.go
@@ -25,20 +25,11 @@ func (c *Client) ListGroupMembers(ctx context.Context, groups []*gl.Group) (Grou
 				PerPage: 100,
 			},
 		}
-		var members []*gl.GroupMember
-		for {
-			page, resp, err := c.api.Groups.ListGroupMembers(g.ID, opts, gl.WithContext(ctx))
-			if err != nil {
-				if skipInaccessible(err, "group members", g.FullPath) {
-					break
-				}
-				return nil, fmt.Errorf("listing members for group %d: %w", g.ID, err)
-			}
-			members = append(members, page...)
-			if resp.NextPage == 0 {
-				break
-			}
-			opts.Page = resp.NextPage
+		members, err := paginate(&opts.ListOptions, "group members", g.FullPath, func() ([]*gl.GroupMember, *gl.Response, error) {
+			return c.api.Groups.ListGroupMembers(g.ID, opts, gl.WithContext(ctx))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing members for group %d: %w", g.ID, err)
 		}
 		if len(members) > 0 {
 			result[g.ID] = members

--- a/internal/gitlab/groups.go
+++ b/internal/gitlab/groups.go
@@ -8,7 +8,7 @@ import (
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func (c *Client) ListGroups(ctx context.Context) ([]*gl.Group, error) {
+func (c *Client) ListGroups(ctx context.Context, cfg FilterConfig) ([]*gl.Group, error) {
 	var allGroups []*gl.Group
 
 	if c.group != "" {
@@ -38,7 +38,7 @@ func (c *Client) ListGroups(ctx context.Context) ([]*gl.Group, error) {
 			}
 			opts.Page = resp.NextPage
 		}
-		return filterDeletedGroups(allGroups), nil
+		return filterGroups(allGroups, cfg), nil
 	}
 
 	opts := &gl.ListGroupsOptions{
@@ -58,17 +58,5 @@ func (c *Client) ListGroups(ctx context.Context) ([]*gl.Group, error) {
 		}
 		opts.Page = resp.NextPage
 	}
-	return filterDeletedGroups(allGroups), nil
-}
-
-func filterDeletedGroups(groups []*gl.Group) []*gl.Group {
-	filtered := make([]*gl.Group, 0, len(groups))
-	for _, g := range groups {
-		if g.MarkedForDeletionOn != nil {
-			slog.Debug("skipping group pending deletion", "group", g.FullPath)
-			continue
-		}
-		filtered = append(filtered, g)
-	}
-	return filtered
+	return filterGroups(allGroups, cfg), nil
 }

--- a/internal/gitlab/groups_test.go
+++ b/internal/gitlab/groups_test.go
@@ -1,0 +1,27 @@
+package gitlab
+
+import (
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+func TestFilterDeletedGroups(t *testing.T) {
+	marked := &gl.ISOTime{}
+	groups := []*gl.Group{
+		{ID: 1, FullPath: "keep"},
+		{ID: 2, FullPath: "deleting", MarkedForDeletionOn: marked},
+		{ID: 3, FullPath: "keep2"},
+	}
+
+	got := filterDeletedGroups(groups)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 groups after filtering, got %d", len(got))
+	}
+	for _, g := range got {
+		if g.MarkedForDeletionOn != nil {
+			t.Errorf("group %q is marked for deletion and should have been filtered", g.FullPath)
+		}
+	}
+}

--- a/internal/gitlab/groups_test.go
+++ b/internal/gitlab/groups_test.go
@@ -6,7 +6,7 @@ import (
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func TestFilterDeletedGroups(t *testing.T) {
+func TestFilterGroups(t *testing.T) {
 	marked := &gl.ISOTime{}
 	groups := []*gl.Group{
 		{ID: 1, FullPath: "keep"},
@@ -14,14 +14,22 @@ func TestFilterDeletedGroups(t *testing.T) {
 		{ID: 3, FullPath: "keep2"},
 	}
 
-	got := filterDeletedGroups(groups)
-
-	if len(got) != 2 {
-		t.Fatalf("expected 2 groups after filtering, got %d", len(got))
-	}
-	for _, g := range got {
-		if g.MarkedForDeletionOn != nil {
-			t.Errorf("group %q is marked for deletion and should have been filtered", g.FullPath)
+	t.Run("default hides pending-deletion", func(t *testing.T) {
+		got := filterGroups(groups, FilterConfig{})
+		if len(got) != 2 {
+			t.Fatalf("expected 2 groups, got %d", len(got))
 		}
-	}
+		for _, g := range got {
+			if g.MarkedForDeletionOn != nil {
+				t.Errorf("group %q pending deletion should be hidden", g.FullPath)
+			}
+		}
+	})
+
+	t.Run("ShowPendingDeletion keeps them", func(t *testing.T) {
+		got := filterGroups(groups, FilterConfig{ShowPendingDeletion: true})
+		if len(got) != 3 {
+			t.Fatalf("expected all 3 groups, got %d", len(got))
+		}
+	})
 }

--- a/internal/gitlab/hooks.go
+++ b/internal/gitlab/hooks.go
@@ -2,10 +2,8 @@ package gitlab
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
-	"net/http"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
 )
@@ -34,6 +32,9 @@ func (c *Client) ListProjectHooks(ctx context.Context, projects []*gl.Project) (
 		for {
 			page, resp, err := c.api.Projects.ListProjectHooks(p.ID, opts, gl.WithContext(ctx))
 			if err != nil {
+				if skipInaccessible(err, "project hooks", p.PathWithNamespace) {
+					break
+				}
 				return nil, fmt.Errorf("listing hooks for project %d: %w", p.ID, err)
 			}
 			hooks = append(hooks, page...)
@@ -67,9 +68,9 @@ func (c *Client) ListGroupHooks(ctx context.Context, groups []*gl.Group) (GroupH
 		for {
 			page, resp, err := c.api.Groups.ListGroupHooks(g.ID, opts, gl.WithContext(ctx))
 			if err != nil {
-				var errResp *gl.ErrorResponse
-				if errors.As(err, &errResp) && errResp.HasStatusCode(http.StatusForbidden) {
-					slog.Warn("group hooks require Premium/Ultimate, skipping", "group", g.FullPath)
+				// Group hooks require Premium/Ultimate; a 403 here is expected on
+				// Free and is skipped along with any other inaccessible group.
+				if skipInaccessible(err, "group hooks", g.FullPath) {
 					break
 				}
 				return nil, fmt.Errorf("listing hooks for group %d: %w", g.ID, err)

--- a/internal/gitlab/hooks.go
+++ b/internal/gitlab/hooks.go
@@ -28,20 +28,11 @@ func (c *Client) ListProjectHooks(ctx context.Context, projects []*gl.Project) (
 				PerPage: 100,
 			},
 		}
-		var hooks []*gl.ProjectHook
-		for {
-			page, resp, err := c.api.Projects.ListProjectHooks(p.ID, opts, gl.WithContext(ctx))
-			if err != nil {
-				if skipInaccessible(err, "project hooks", p.PathWithNamespace) {
-					break
-				}
-				return nil, fmt.Errorf("listing hooks for project %d: %w", p.ID, err)
-			}
-			hooks = append(hooks, page...)
-			if resp.NextPage == 0 {
-				break
-			}
-			opts.Page = resp.NextPage
+		hooks, err := paginate(&opts.ListOptions, "project hooks", p.PathWithNamespace, func() ([]*gl.ProjectHook, *gl.Response, error) {
+			return c.api.Projects.ListProjectHooks(p.ID, opts, gl.WithContext(ctx))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing hooks for project %d: %w", p.ID, err)
 		}
 		if len(hooks) > 0 {
 			result[p.ID] = hooks
@@ -64,22 +55,13 @@ func (c *Client) ListGroupHooks(ctx context.Context, groups []*gl.Group) (GroupH
 				PerPage: 100,
 			},
 		}
-		var hooks []*gl.GroupHook
-		for {
-			page, resp, err := c.api.Groups.ListGroupHooks(g.ID, opts, gl.WithContext(ctx))
-			if err != nil {
-				// Group hooks require Premium/Ultimate; a 403 here is expected on
-				// Free and is skipped along with any other inaccessible group.
-				if skipInaccessible(err, "group hooks", g.FullPath) {
-					break
-				}
-				return nil, fmt.Errorf("listing hooks for group %d: %w", g.ID, err)
-			}
-			hooks = append(hooks, page...)
-			if resp.NextPage == 0 {
-				break
-			}
-			opts.Page = resp.NextPage
+		// Group hooks require Premium/Ultimate; a 403 here is expected on Free and
+		// is skipped (via paginate's skipInaccessible) like any inaccessible group.
+		hooks, err := paginate(&opts.ListOptions, "group hooks", g.FullPath, func() ([]*gl.GroupHook, *gl.Response, error) {
+			return c.api.Groups.ListGroupHooks(g.ID, opts, gl.WithContext(ctx))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing hooks for group %d: %w", g.ID, err)
 		}
 		if len(hooks) > 0 {
 			result[g.ID] = hooks

--- a/internal/gitlab/job_token_scopes.go
+++ b/internal/gitlab/job_token_scopes.go
@@ -19,6 +19,7 @@ type JobTokenScopes = map[int64]*JobTokenScope
 func (c *Client) ListJobTokenScopes(ctx context.Context, projects []*gl.Project) (JobTokenScopes, error) {
 	result := make(JobTokenScopes, len(projects))
 
+projectLoop:
 	for _, p := range projects {
 		if p == nil {
 			continue
@@ -33,24 +34,48 @@ func (c *Client) ListJobTokenScopes(ctx context.Context, projects []*gl.Project)
 			return nil, fmt.Errorf("getting job token access settings for project %d: %w", p.ID, err)
 		}
 
+		// The job token scope is a composite resource (settings + both
+		// allowlists). These allowlist fetches deliberately do NOT use the
+		// graceful paginate helper: if an allowlist is inaccessible we skip the
+		// whole project (continue projectLoop) rather than emit a scope with a
+		// misleadingly-empty allowlist, which would read as drift — and on apply
+		// would delete entries we merely could not read.
 		projectOpts := &gl.GetJobTokenInboundAllowListOptions{
 			ListOptions: gl.ListOptions{Page: 1, PerPage: 100},
 		}
-		allowedProjects, err := paginate(&projectOpts.ListOptions, "job token inbound allowlist", p.PathWithNamespace, func() ([]*gl.Project, *gl.Response, error) {
-			return c.api.JobTokenScope.GetProjectJobTokenInboundAllowList(p.ID, projectOpts, gl.WithContext(ctx))
-		})
-		if err != nil {
-			return nil, fmt.Errorf("listing job token inbound allowlist projects for project %d: %w", p.ID, err)
+		var allowedProjects []*gl.Project
+		for {
+			page, resp, err := c.api.JobTokenScope.GetProjectJobTokenInboundAllowList(p.ID, projectOpts, gl.WithContext(ctx))
+			if err != nil {
+				if skipInaccessible(err, "job token inbound allowlist", p.PathWithNamespace) {
+					continue projectLoop
+				}
+				return nil, fmt.Errorf("listing job token inbound allowlist projects for project %d: %w", p.ID, err)
+			}
+			allowedProjects = append(allowedProjects, page...)
+			if resp.NextPage == 0 {
+				break
+			}
+			projectOpts.Page = resp.NextPage
 		}
 
 		groupOpts := &gl.GetJobTokenAllowlistGroupsOptions{
 			ListOptions: gl.ListOptions{Page: 1, PerPage: 100},
 		}
-		allowedGroups, err := paginate(&groupOpts.ListOptions, "job token allowlist groups", p.PathWithNamespace, func() ([]*gl.Group, *gl.Response, error) {
-			return c.api.JobTokenScope.GetJobTokenAllowlistGroups(p.ID, groupOpts, gl.WithContext(ctx))
-		})
-		if err != nil {
-			return nil, fmt.Errorf("listing job token allowlist groups for project %d: %w", p.ID, err)
+		var allowedGroups []*gl.Group
+		for {
+			page, resp, err := c.api.JobTokenScope.GetJobTokenAllowlistGroups(p.ID, groupOpts, gl.WithContext(ctx))
+			if err != nil {
+				if skipInaccessible(err, "job token allowlist groups", p.PathWithNamespace) {
+					continue projectLoop
+				}
+				return nil, fmt.Errorf("listing job token allowlist groups for project %d: %w", p.ID, err)
+			}
+			allowedGroups = append(allowedGroups, page...)
+			if resp.NextPage == 0 {
+				break
+			}
+			groupOpts.Page = resp.NextPage
 		}
 
 		// Mirror the provider's Read behavior so HCL matches state.

--- a/internal/gitlab/job_token_scopes.go
+++ b/internal/gitlab/job_token_scopes.go
@@ -36,39 +36,21 @@ func (c *Client) ListJobTokenScopes(ctx context.Context, projects []*gl.Project)
 		projectOpts := &gl.GetJobTokenInboundAllowListOptions{
 			ListOptions: gl.ListOptions{Page: 1, PerPage: 100},
 		}
-		var allowedProjects []*gl.Project
-		for {
-			page, resp, err := c.api.JobTokenScope.GetProjectJobTokenInboundAllowList(p.ID, projectOpts, gl.WithContext(ctx))
-			if err != nil {
-				if skipInaccessible(err, "job token inbound allowlist", p.PathWithNamespace) {
-					break
-				}
-				return nil, fmt.Errorf("listing job token inbound allowlist projects for project %d: %w", p.ID, err)
-			}
-			allowedProjects = append(allowedProjects, page...)
-			if resp.NextPage == 0 {
-				break
-			}
-			projectOpts.Page = resp.NextPage
+		allowedProjects, err := paginate(&projectOpts.ListOptions, "job token inbound allowlist", p.PathWithNamespace, func() ([]*gl.Project, *gl.Response, error) {
+			return c.api.JobTokenScope.GetProjectJobTokenInboundAllowList(p.ID, projectOpts, gl.WithContext(ctx))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing job token inbound allowlist projects for project %d: %w", p.ID, err)
 		}
 
 		groupOpts := &gl.GetJobTokenAllowlistGroupsOptions{
 			ListOptions: gl.ListOptions{Page: 1, PerPage: 100},
 		}
-		var allowedGroups []*gl.Group
-		for {
-			page, resp, err := c.api.JobTokenScope.GetJobTokenAllowlistGroups(p.ID, groupOpts, gl.WithContext(ctx))
-			if err != nil {
-				if skipInaccessible(err, "job token allowlist groups", p.PathWithNamespace) {
-					break
-				}
-				return nil, fmt.Errorf("listing job token allowlist groups for project %d: %w", p.ID, err)
-			}
-			allowedGroups = append(allowedGroups, page...)
-			if resp.NextPage == 0 {
-				break
-			}
-			groupOpts.Page = resp.NextPage
+		allowedGroups, err := paginate(&groupOpts.ListOptions, "job token allowlist groups", p.PathWithNamespace, func() ([]*gl.Group, *gl.Response, error) {
+			return c.api.JobTokenScope.GetJobTokenAllowlistGroups(p.ID, groupOpts, gl.WithContext(ctx))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing job token allowlist groups for project %d: %w", p.ID, err)
 		}
 
 		// Mirror the provider's Read behavior so HCL matches state.

--- a/internal/gitlab/job_token_scopes.go
+++ b/internal/gitlab/job_token_scopes.go
@@ -27,6 +27,9 @@ func (c *Client) ListJobTokenScopes(ctx context.Context, projects []*gl.Project)
 
 		settings, _, err := c.api.JobTokenScope.GetProjectJobTokenAccessSettings(p.ID, gl.WithContext(ctx))
 		if err != nil {
+			if skipInaccessible(err, "job token scopes", p.PathWithNamespace) {
+				continue
+			}
 			return nil, fmt.Errorf("getting job token access settings for project %d: %w", p.ID, err)
 		}
 
@@ -37,6 +40,9 @@ func (c *Client) ListJobTokenScopes(ctx context.Context, projects []*gl.Project)
 		for {
 			page, resp, err := c.api.JobTokenScope.GetProjectJobTokenInboundAllowList(p.ID, projectOpts, gl.WithContext(ctx))
 			if err != nil {
+				if skipInaccessible(err, "job token inbound allowlist", p.PathWithNamespace) {
+					break
+				}
 				return nil, fmt.Errorf("listing job token inbound allowlist projects for project %d: %w", p.ID, err)
 			}
 			allowedProjects = append(allowedProjects, page...)
@@ -53,6 +59,9 @@ func (c *Client) ListJobTokenScopes(ctx context.Context, projects []*gl.Project)
 		for {
 			page, resp, err := c.api.JobTokenScope.GetJobTokenAllowlistGroups(p.ID, groupOpts, gl.WithContext(ctx))
 			if err != nil {
+				if skipInaccessible(err, "job token allowlist groups", p.PathWithNamespace) {
+					break
+				}
 				return nil, fmt.Errorf("listing job token allowlist groups for project %d: %w", p.ID, err)
 			}
 			allowedGroups = append(allowedGroups, page...)

--- a/internal/gitlab/job_token_scopes_test.go
+++ b/internal/gitlab/job_token_scopes_test.go
@@ -2,12 +2,38 @@ package gitlab
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
 	gitlabtesting "gitlab.com/gitlab-org/api/client-go/v2/testing"
 	"go.uber.org/mock/gomock"
 )
+
+// A job token scope is a composite resource (settings + two allowlists). If an
+// allowlist is inaccessible we must skip the WHOLE project, not emit a scope
+// with a misleadingly-empty allowlist (which would look like drift / delete
+// entries on apply). The inbound 403 here must skip project 1 entirely — and
+// the groups allowlist must therefore never be requested.
+func TestListJobTokenScopes_SkipsProjectWhenAllowlistInaccessible(t *testing.T) {
+	tc := gitlabtesting.NewTestClient(t)
+	c := NewClientFromAPI(tc.Client, "mygroup")
+
+	tc.MockJobTokenScope.EXPECT().
+		GetProjectJobTokenAccessSettings(gomock.Any(), gomock.Any()).
+		Return(&gl.JobTokenAccessSettings{InboundEnabled: true}, &gl.Response{}, nil)
+	tc.MockJobTokenScope.EXPECT().
+		GetProjectJobTokenInboundAllowList(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil, &gl.ErrorResponse{StatusCode: http.StatusForbidden})
+
+	result, err := c.ListJobTokenScopes(context.Background(), []*gl.Project{{ID: 1, PathWithNamespace: "mygroup/proj"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := result[1]; ok {
+		t.Errorf("project with an inaccessible allowlist must be skipped entirely, got %+v", result[1])
+	}
+}
 
 // The provider strips a single self entry on Read; we mirror that so the emitted
 // HCL matches state (see the long comment in job_token_scopes.go).

--- a/internal/gitlab/job_token_scopes_test.go
+++ b/internal/gitlab/job_token_scopes_test.go
@@ -1,0 +1,77 @@
+package gitlab
+
+import (
+	"context"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+	gitlabtesting "gitlab.com/gitlab-org/api/client-go/v2/testing"
+	"go.uber.org/mock/gomock"
+)
+
+// The provider strips a single self entry on Read; we mirror that so the emitted
+// HCL matches state (see the long comment in job_token_scopes.go).
+func TestListJobTokenScopes_SelfDedup(t *testing.T) {
+	t.Run("self appearing once is stripped", func(t *testing.T) {
+		tc := gitlabtesting.NewTestClient(t)
+		c := NewClientFromAPI(tc.Client, "mygroup")
+
+		tc.MockJobTokenScope.EXPECT().
+			GetProjectJobTokenAccessSettings(gomock.Any(), gomock.Any()).
+			Return(&gl.JobTokenAccessSettings{InboundEnabled: true}, &gl.Response{}, nil)
+		tc.MockJobTokenScope.EXPECT().
+			GetProjectJobTokenInboundAllowList(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]*gl.Project{{ID: 1}, {ID: 2}}, &gl.Response{}, nil)
+		tc.MockJobTokenScope.EXPECT().
+			GetJobTokenAllowlistGroups(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, &gl.Response{}, nil)
+
+		result, err := c.ListJobTokenScopes(context.Background(), []*gl.Project{{ID: 1, PathWithNamespace: "mygroup/proj"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		scope := result[1]
+		if scope == nil {
+			t.Fatal("expected a scope for project 1")
+		}
+		if len(scope.AllowedProjects) != 1 || scope.AllowedProjects[0].ID != 2 {
+			t.Errorf("self appearing once should be stripped, leaving only project 2; got %v", scope.AllowedProjects)
+		}
+	})
+
+	t.Run("self appearing twice is kept once", func(t *testing.T) {
+		tc := gitlabtesting.NewTestClient(t)
+		c := NewClientFromAPI(tc.Client, "mygroup")
+
+		tc.MockJobTokenScope.EXPECT().
+			GetProjectJobTokenAccessSettings(gomock.Any(), gomock.Any()).
+			Return(&gl.JobTokenAccessSettings{InboundEnabled: true}, &gl.Response{}, nil)
+		tc.MockJobTokenScope.EXPECT().
+			GetProjectJobTokenInboundAllowList(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]*gl.Project{{ID: 1}, {ID: 1}, {ID: 2}}, &gl.Response{}, nil)
+		tc.MockJobTokenScope.EXPECT().
+			GetJobTokenAllowlistGroups(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, &gl.Response{}, nil)
+
+		result, err := c.ListJobTokenScopes(context.Background(), []*gl.Project{{ID: 1, PathWithNamespace: "mygroup/proj"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		scope := result[1]
+		if scope == nil {
+			t.Fatal("expected a scope for project 1")
+		}
+		var hasSelf, hasTwo bool
+		for _, ap := range scope.AllowedProjects {
+			switch ap.ID {
+			case 1:
+				hasSelf = true
+			case 2:
+				hasTwo = true
+			}
+		}
+		if len(scope.AllowedProjects) != 2 || !hasSelf || !hasTwo {
+			t.Errorf("self appearing twice should be kept once alongside project 2; got %v", scope.AllowedProjects)
+		}
+	})
+}

--- a/internal/gitlab/labels.go
+++ b/internal/gitlab/labels.go
@@ -30,20 +30,11 @@ func (c *Client) ListGroupLabels(ctx context.Context, groups []*gl.Group) (Group
 			},
 			OnlyGroupLabels: gl.Ptr(true),
 		}
-		var labels []*gl.GroupLabel
-		for {
-			page, resp, err := c.api.GroupLabels.ListGroupLabels(g.ID, opts, gl.WithContext(ctx))
-			if err != nil {
-				if skipInaccessible(err, "group labels", g.FullPath) {
-					break
-				}
-				return nil, fmt.Errorf("listing labels for group %d: %w", g.ID, err)
-			}
-			labels = append(labels, page...)
-			if resp.NextPage == 0 {
-				break
-			}
-			opts.Page = resp.NextPage
+		labels, err := paginate(&opts.ListOptions, "group labels", g.FullPath, func() ([]*gl.GroupLabel, *gl.Response, error) {
+			return c.api.GroupLabels.ListGroupLabels(g.ID, opts, gl.WithContext(ctx))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing labels for group %d: %w", g.ID, err)
 		}
 		var owned []*gl.GroupLabel
 		for _, l := range labels {
@@ -74,24 +65,17 @@ func (c *Client) ListProjectLabels(ctx context.Context, projects []*gl.Project) 
 				PerPage: 100,
 			},
 		}
+		all, err := paginate(&opts.ListOptions, "project labels", p.PathWithNamespace, func() ([]*gl.Label, *gl.Response, error) {
+			return c.api.Labels.ListLabels(p.ID, opts, gl.WithContext(ctx))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing labels for project %d: %w", p.ID, err)
+		}
 		var labels []*gl.Label
-		for {
-			page, resp, err := c.api.Labels.ListLabels(p.ID, opts, gl.WithContext(ctx))
-			if err != nil {
-				if skipInaccessible(err, "project labels", p.PathWithNamespace) {
-					break
-				}
-				return nil, fmt.Errorf("listing labels for project %d: %w", p.ID, err)
+		for _, l := range all {
+			if l.IsProjectLabel {
+				labels = append(labels, l)
 			}
-			for _, l := range page {
-				if l.IsProjectLabel {
-					labels = append(labels, l)
-				}
-			}
-			if resp.NextPage == 0 {
-				break
-			}
-			opts.Page = resp.NextPage
 		}
 		if len(labels) > 0 {
 			result[p.ID] = labels

--- a/internal/gitlab/labels.go
+++ b/internal/gitlab/labels.go
@@ -34,6 +34,9 @@ func (c *Client) ListGroupLabels(ctx context.Context, groups []*gl.Group) (Group
 		for {
 			page, resp, err := c.api.GroupLabels.ListGroupLabels(g.ID, opts, gl.WithContext(ctx))
 			if err != nil {
+				if skipInaccessible(err, "group labels", g.FullPath) {
+					break
+				}
 				return nil, fmt.Errorf("listing labels for group %d: %w", g.ID, err)
 			}
 			labels = append(labels, page...)
@@ -75,6 +78,9 @@ func (c *Client) ListProjectLabels(ctx context.Context, projects []*gl.Project) 
 		for {
 			page, resp, err := c.api.Labels.ListLabels(p.ID, opts, gl.WithContext(ctx))
 			if err != nil {
+				if skipInaccessible(err, "project labels", p.PathWithNamespace) {
+					break
+				}
 				return nil, fmt.Errorf("listing labels for project %d: %w", p.ID, err)
 			}
 			for _, l := range page {

--- a/internal/gitlab/pagination.go
+++ b/internal/gitlab/pagination.go
@@ -1,0 +1,29 @@
+package gitlab
+
+import gl "gitlab.com/gitlab-org/api/client-go/v2"
+
+// paginate walks a GitLab list endpoint to completion, concatenating every page.
+// fetch performs one request with the current options; paginate advances the
+// page cursor via listOpts.Page between calls.
+//
+// A 403/404 is treated as "inaccessible": paginate stops and returns whatever it
+// has collected so far with no error (see skipInaccessible), so one restricted or
+// just-deleted parent never aborts the whole scan. Any other error is returned
+// for the caller to wrap with resource-specific context.
+func paginate[T any](listOpts *gl.ListOptions, resource, path string, fetch func() ([]T, *gl.Response, error)) ([]T, error) {
+	var all []T
+	for {
+		page, resp, err := fetch()
+		if err != nil {
+			if skipInaccessible(err, resource, path) {
+				return all, nil
+			}
+			return nil, err
+		}
+		all = append(all, page...)
+		if resp.NextPage == 0 {
+			return all, nil
+		}
+		listOpts.Page = resp.NextPage
+	}
+}

--- a/internal/gitlab/pagination_test.go
+++ b/internal/gitlab/pagination_test.go
@@ -1,0 +1,57 @@
+package gitlab
+
+import (
+	"net/http"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+func TestPaginate_CollectsAllPages(t *testing.T) {
+	opts := &gl.ListOptions{Page: 1, PerPage: 100}
+	calls := 0
+	fetch := func() ([]int, *gl.Response, error) {
+		calls++
+		if calls == 1 {
+			return []int{1, 2}, &gl.Response{NextPage: 2}, nil
+		}
+		return []int{3}, &gl.Response{NextPage: 0}, nil
+	}
+
+	got, err := paginate(opts, "test", "path", fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 || got[0] != 1 || got[2] != 3 {
+		t.Errorf("got %v, want [1 2 3]", got)
+	}
+	if opts.Page != 2 {
+		t.Errorf("opts.Page = %d, want 2 (advanced to last fetched page)", opts.Page)
+	}
+}
+
+func TestPaginate_SkipsOnForbidden(t *testing.T) {
+	opts := &gl.ListOptions{Page: 1, PerPage: 100}
+	fetch := func() ([]int, *gl.Response, error) {
+		return nil, nil, &gl.ErrorResponse{StatusCode: http.StatusForbidden}
+	}
+
+	got, err := paginate(opts, "test", "path", fetch)
+	if err != nil {
+		t.Fatalf("forbidden should be skipped, not returned as error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestPaginate_PropagatesOtherErrors(t *testing.T) {
+	opts := &gl.ListOptions{Page: 1, PerPage: 100}
+	fetch := func() ([]int, *gl.Response, error) {
+		return nil, nil, &gl.ErrorResponse{StatusCode: http.StatusInternalServerError}
+	}
+
+	if _, err := paginate(opts, "test", "path", fetch); err == nil {
+		t.Error("expected a non-skippable error to propagate")
+	}
+}

--- a/internal/gitlab/pipeline_schedules.go
+++ b/internal/gitlab/pipeline_schedules.go
@@ -24,20 +24,11 @@ func (c *Client) ListPipelineSchedules(ctx context.Context, projects []*gl.Proje
 				PerPage: 100,
 			},
 		}
-		var schedules []*gl.PipelineSchedule
-		for {
-			page, resp, err := c.api.PipelineSchedules.ListPipelineSchedules(p.ID, opts, gl.WithContext(ctx))
-			if err != nil {
-				if skipInaccessible(err, "pipeline schedules", p.PathWithNamespace) {
-					break
-				}
-				return nil, fmt.Errorf("listing pipeline schedules for project %d: %w", p.ID, err)
-			}
-			schedules = append(schedules, page...)
-			if resp.NextPage == 0 {
-				break
-			}
-			opts.Page = resp.NextPage
+		schedules, err := paginate(&opts.ListOptions, "pipeline schedules", p.PathWithNamespace, func() ([]*gl.PipelineSchedule, *gl.Response, error) {
+			return c.api.PipelineSchedules.ListPipelineSchedules(p.ID, opts, gl.WithContext(ctx))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing pipeline schedules for project %d: %w", p.ID, err)
 		}
 
 		// Fetch detail for each schedule to get variables.

--- a/internal/gitlab/pipeline_schedules.go
+++ b/internal/gitlab/pipeline_schedules.go
@@ -28,6 +28,9 @@ func (c *Client) ListPipelineSchedules(ctx context.Context, projects []*gl.Proje
 		for {
 			page, resp, err := c.api.PipelineSchedules.ListPipelineSchedules(p.ID, opts, gl.WithContext(ctx))
 			if err != nil {
+				if skipInaccessible(err, "pipeline schedules", p.PathWithNamespace) {
+					break
+				}
 				return nil, fmt.Errorf("listing pipeline schedules for project %d: %w", p.ID, err)
 			}
 			schedules = append(schedules, page...)
@@ -43,6 +46,9 @@ func (c *Client) ListPipelineSchedules(ctx context.Context, projects []*gl.Proje
 			slog.Debug("fetching pipeline schedule detail", "project", p.PathWithNamespace, "schedule", s.ID)
 			d, _, err := c.api.PipelineSchedules.GetPipelineSchedule(p.ID, s.ID, gl.WithContext(ctx))
 			if err != nil {
+				if skipInaccessible(err, "pipeline schedule detail", p.PathWithNamespace) {
+					continue
+				}
 				return nil, fmt.Errorf("getting pipeline schedule %d for project %d: %w", s.ID, p.ID, err)
 			}
 			detailed = append(detailed, d)

--- a/internal/gitlab/projects.go
+++ b/internal/gitlab/projects.go
@@ -3,12 +3,11 @@ package gitlab
 import (
 	"context"
 	"fmt"
-	"log/slog"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func (c *Client) ListProjects(ctx context.Context) ([]*gl.Project, error) {
+func (c *Client) ListProjects(ctx context.Context, cfg FilterConfig) ([]*gl.Project, error) {
 	var allProjects []*gl.Project
 
 	if c.group != "" {
@@ -30,7 +29,7 @@ func (c *Client) ListProjects(ctx context.Context) ([]*gl.Project, error) {
 			}
 			opts.Page = resp.NextPage
 		}
-		return filterDeletedProjects(allProjects), nil
+		return filterProjects(allProjects, cfg), nil
 	}
 
 	opts := &gl.ListProjectsOptions{
@@ -50,17 +49,5 @@ func (c *Client) ListProjects(ctx context.Context) ([]*gl.Project, error) {
 		}
 		opts.Page = resp.NextPage
 	}
-	return filterDeletedProjects(allProjects), nil
-}
-
-func filterDeletedProjects(projects []*gl.Project) []*gl.Project {
-	filtered := make([]*gl.Project, 0, len(projects))
-	for _, p := range projects {
-		if p.MarkedForDeletionOn != nil {
-			slog.Debug("skipping project pending deletion", "project", p.PathWithNamespace)
-			continue
-		}
-		filtered = append(filtered, p)
-	}
-	return filtered
+	return filterProjects(allProjects, cfg), nil
 }

--- a/internal/gitlab/projects_test.go
+++ b/internal/gitlab/projects_test.go
@@ -1,0 +1,27 @@
+package gitlab
+
+import (
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+func TestFilterDeletedProjects(t *testing.T) {
+	marked := &gl.ISOTime{}
+	projects := []*gl.Project{
+		{ID: 1, PathWithNamespace: "g/keep"},
+		{ID: 2, PathWithNamespace: "g/deleting", MarkedForDeletionOn: marked},
+		{ID: 3, PathWithNamespace: "g/keep2"},
+	}
+
+	got := filterDeletedProjects(projects)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 projects after filtering, got %d", len(got))
+	}
+	for _, p := range got {
+		if p.MarkedForDeletionOn != nil {
+			t.Errorf("project %q is marked for deletion and should have been filtered", p.PathWithNamespace)
+		}
+	}
+}

--- a/internal/gitlab/projects_test.go
+++ b/internal/gitlab/projects_test.go
@@ -6,22 +6,42 @@ import (
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-func TestFilterDeletedProjects(t *testing.T) {
+func TestFilterProjects(t *testing.T) {
 	marked := &gl.ISOTime{}
 	projects := []*gl.Project{
 		{ID: 1, PathWithNamespace: "g/keep"},
 		{ID: 2, PathWithNamespace: "g/deleting", MarkedForDeletionOn: marked},
-		{ID: 3, PathWithNamespace: "g/keep2"},
+		{ID: 3, PathWithNamespace: "g/archived", Archived: true},
 	}
 
-	got := filterDeletedProjects(projects)
-
-	if len(got) != 2 {
-		t.Fatalf("expected 2 projects after filtering, got %d", len(got))
-	}
-	for _, p := range got {
-		if p.MarkedForDeletionOn != nil {
-			t.Errorf("project %q is marked for deletion and should have been filtered", p.PathWithNamespace)
+	t.Run("default hides pending-deletion, keeps archived", func(t *testing.T) {
+		got := filterProjects(projects, FilterConfig{})
+		ids := projectIDs(got)
+		if len(ids) != 2 || !ids[1] || !ids[3] {
+			t.Fatalf("expected projects 1 and 3 (archived shown), got %v", ids)
 		}
+	})
+
+	t.Run("ShowPendingDeletion keeps the deleting project", func(t *testing.T) {
+		got := filterProjects(projects, FilterConfig{ShowPendingDeletion: true})
+		if len(got) != 3 {
+			t.Fatalf("expected all 3 projects, got %d", len(got))
+		}
+	})
+
+	t.Run("HideArchived drops the archived project", func(t *testing.T) {
+		got := filterProjects(projects, FilterConfig{HideArchived: true})
+		ids := projectIDs(got)
+		if len(ids) != 1 || !ids[1] {
+			t.Fatalf("expected only project 1, got %v", ids)
+		}
+	})
+}
+
+func projectIDs(projects []*gl.Project) map[int64]bool {
+	ids := make(map[int64]bool, len(projects))
+	for _, p := range projects {
+		ids[p.ID] = true
 	}
+	return ids
 }

--- a/internal/gitlab/tag_protections.go
+++ b/internal/gitlab/tag_protections.go
@@ -29,6 +29,9 @@ func (c *Client) ListProtectedTags(ctx context.Context, projects []*gl.Project) 
 		for {
 			page, resp, err := c.api.ProtectedTags.ListProtectedTags(p.ID, opts, gl.WithContext(ctx))
 			if err != nil {
+				if skipInaccessible(err, "protected tags", p.PathWithNamespace) {
+					break
+				}
 				return nil, fmt.Errorf("listing protected tags for project %d: %w", p.ID, err)
 			}
 			tags = append(tags, page...)

--- a/internal/gitlab/tag_protections.go
+++ b/internal/gitlab/tag_protections.go
@@ -25,20 +25,11 @@ func (c *Client) ListProtectedTags(ctx context.Context, projects []*gl.Project) 
 				PerPage: 100,
 			},
 		}
-		var tags []*gl.ProtectedTag
-		for {
-			page, resp, err := c.api.ProtectedTags.ListProtectedTags(p.ID, opts, gl.WithContext(ctx))
-			if err != nil {
-				if skipInaccessible(err, "protected tags", p.PathWithNamespace) {
-					break
-				}
-				return nil, fmt.Errorf("listing protected tags for project %d: %w", p.ID, err)
-			}
-			tags = append(tags, page...)
-			if resp.NextPage == 0 {
-				break
-			}
-			opts.Page = resp.NextPage
+		tags, err := paginate(&opts.ListOptions, "protected tags", p.PathWithNamespace, func() ([]*gl.ProtectedTag, *gl.Response, error) {
+			return c.api.ProtectedTags.ListProtectedTags(p.ID, opts, gl.WithContext(ctx))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing protected tags for project %d: %w", p.ID, err)
 		}
 		if len(tags) > 0 {
 			result[p.ID] = tags

--- a/internal/gitlab/variables.go
+++ b/internal/gitlab/variables.go
@@ -28,34 +28,27 @@ func (c *Client) ListProjectVariables(ctx context.Context, projects []*gl.Projec
 				PerPage: 100,
 			},
 		}
+		all, err := paginate(&opts.ListOptions, "project variables", p.PathWithNamespace, func() ([]*gl.ProjectVariable, *gl.Response, error) {
+			return c.api.ProjectVariables.ListVariables(p.ID, opts, gl.WithContext(ctx))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing variables for project %d: %w", p.ID, err)
+		}
 		var vars []*gl.ProjectVariable
-		for {
-			page, resp, err := c.api.ProjectVariables.ListVariables(p.ID, opts, gl.WithContext(ctx))
-			if err != nil {
-				if skipInaccessible(err, "project variables", p.PathWithNamespace) {
-					break
-				}
-				return nil, fmt.Errorf("listing variables for project %d: %w", p.ID, err)
+		for _, v := range all {
+			if v.Masked {
+				slog.Debug("skipping masked variable", "key", v.Key, "project", p.PathWithNamespace)
+				continue
 			}
-			for _, v := range page {
-				if v.Masked {
-					slog.Debug("skipping masked variable", "key", v.Key, "project", p.PathWithNamespace)
-					continue
-				}
-				if v.Hidden {
-					slog.Debug("skipping hidden variable", "key", v.Key, "project", p.PathWithNamespace)
-					continue
-				}
-				if v.VariableType == gl.FileVariableType {
-					slog.Debug("skipping file variable", "key", v.Key, "project", p.PathWithNamespace)
-					continue
-				}
-				vars = append(vars, v)
+			if v.Hidden {
+				slog.Debug("skipping hidden variable", "key", v.Key, "project", p.PathWithNamespace)
+				continue
 			}
-			if resp.NextPage == 0 {
-				break
+			if v.VariableType == gl.FileVariableType {
+				slog.Debug("skipping file variable", "key", v.Key, "project", p.PathWithNamespace)
+				continue
 			}
-			opts.Page = resp.NextPage
+			vars = append(vars, v)
 		}
 		if len(vars) > 0 {
 			result[p.ID] = vars
@@ -79,34 +72,27 @@ func (c *Client) ListGroupVariables(ctx context.Context, groups []*gl.Group) (Gr
 				PerPage: 100,
 			},
 		}
+		all, err := paginate(&opts.ListOptions, "group variables", g.FullPath, func() ([]*gl.GroupVariable, *gl.Response, error) {
+			return c.api.GroupVariables.ListVariables(g.ID, opts, gl.WithContext(ctx))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing variables for group %d: %w", g.ID, err)
+		}
 		var vars []*gl.GroupVariable
-		for {
-			page, resp, err := c.api.GroupVariables.ListVariables(g.ID, opts, gl.WithContext(ctx))
-			if err != nil {
-				if skipInaccessible(err, "group variables", g.FullPath) {
-					break
-				}
-				return nil, fmt.Errorf("listing variables for group %d: %w", g.ID, err)
+		for _, v := range all {
+			if v.Masked {
+				slog.Debug("skipping masked variable", "key", v.Key, "group", g.FullPath)
+				continue
 			}
-			for _, v := range page {
-				if v.Masked {
-					slog.Debug("skipping masked variable", "key", v.Key, "group", g.FullPath)
-					continue
-				}
-				if v.Hidden {
-					slog.Debug("skipping hidden variable", "key", v.Key, "group", g.FullPath)
-					continue
-				}
-				if v.VariableType == gl.FileVariableType {
-					slog.Debug("skipping file variable", "key", v.Key, "group", g.FullPath)
-					continue
-				}
-				vars = append(vars, v)
+			if v.Hidden {
+				slog.Debug("skipping hidden variable", "key", v.Key, "group", g.FullPath)
+				continue
 			}
-			if resp.NextPage == 0 {
-				break
+			if v.VariableType == gl.FileVariableType {
+				slog.Debug("skipping file variable", "key", v.Key, "group", g.FullPath)
+				continue
 			}
-			opts.Page = resp.NextPage
+			vars = append(vars, v)
 		}
 		if len(vars) > 0 {
 			result[g.ID] = vars

--- a/internal/gitlab/variables.go
+++ b/internal/gitlab/variables.go
@@ -32,6 +32,9 @@ func (c *Client) ListProjectVariables(ctx context.Context, projects []*gl.Projec
 		for {
 			page, resp, err := c.api.ProjectVariables.ListVariables(p.ID, opts, gl.WithContext(ctx))
 			if err != nil {
+				if skipInaccessible(err, "project variables", p.PathWithNamespace) {
+					break
+				}
 				return nil, fmt.Errorf("listing variables for project %d: %w", p.ID, err)
 			}
 			for _, v := range page {
@@ -80,6 +83,9 @@ func (c *Client) ListGroupVariables(ctx context.Context, groups []*gl.Group) (Gr
 		for {
 			page, resp, err := c.api.GroupVariables.ListVariables(g.ID, opts, gl.WithContext(ctx))
 			if err != nil {
+				if skipInaccessible(err, "group variables", g.FullPath) {
+					break
+				}
 				return nil, fmt.Errorf("listing variables for group %d: %w", g.ID, err)
 			}
 			for _, v := range page {

--- a/internal/gitlab/variables_test.go
+++ b/internal/gitlab/variables_test.go
@@ -1,0 +1,36 @@
+package gitlab
+
+import (
+	"context"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+	gitlabtesting "gitlab.com/gitlab-org/api/client-go/v2/testing"
+	"go.uber.org/mock/gomock"
+)
+
+func TestListProjectVariables_FiltersMaskedHiddenFile(t *testing.T) {
+	tc := gitlabtesting.NewTestClient(t)
+	c := NewClientFromAPI(tc.Client, "mygroup")
+
+	tc.MockProjectVariables.EXPECT().
+		ListVariables(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]*gl.ProjectVariable{
+			{Key: "NORMAL"},
+			{Key: "MASKED", Masked: true},
+			{Key: "HIDDEN", Hidden: true},
+			{Key: "FILE", VariableType: gl.FileVariableType},
+		}, &gl.Response{}, nil)
+
+	projects := []*gl.Project{{ID: 1, PathWithNamespace: "mygroup/proj"}}
+	result, err := c.ListProjectVariables(context.Background(), projects)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result[1]) != 1 {
+		t.Fatalf("expected only the non-masked/hidden/file variable, got %d: %v", len(result[1]), result[1])
+	}
+	if result[1][0].Key != "NORMAL" {
+		t.Errorf("kept variable = %q, want NORMAL", result[1][0].Key)
+	}
+}

--- a/internal/terraform/branch_protections.go
+++ b/internal/terraform/branch_protections.go
@@ -22,11 +22,9 @@ func branchProtectionResourceName(p *gl.Project, b *gl.ProtectedBranch) string {
 // branchProtectionResourceNames returns deterministic, collision-free terraform
 // resource names for one project's protected branches.
 func branchProtectionResourceNames(p *gl.Project, branches []*gl.ProtectedBranch) []string {
-	bases := make([]string, len(branches))
-	for i, b := range branches {
-		bases[i] = branchProtectionResourceName(p, b)
-	}
-	return dedupeResourceNames(bases)
+	return buildResourceNames(branches, func(b *gl.ProtectedBranch) string {
+		return branchProtectionResourceName(p, b)
+	})
 }
 
 const adminAccessLevel gl.AccessLevelValue = 60

--- a/internal/terraform/branch_protections.go
+++ b/internal/terraform/branch_protections.go
@@ -19,6 +19,16 @@ func branchProtectionResourceName(p *gl.Project, b *gl.ProtectedBranch) string {
 	return projectResourceName(p) + "_" + normalizeBranchName(b.Name)
 }
 
+// branchProtectionResourceNames returns deterministic, collision-free terraform
+// resource names for one project's protected branches.
+func branchProtectionResourceNames(p *gl.Project, branches []*gl.ProtectedBranch) []string {
+	bases := make([]string, len(branches))
+	for i, b := range branches {
+		bases[i] = branchProtectionResourceName(p, b)
+	}
+	return dedupeResourceNames(bases)
+}
+
 const adminAccessLevel gl.AccessLevelValue = 60
 
 // protectionAccessLevel maps an access level to the string used by branch and
@@ -60,13 +70,13 @@ func WriteBranchProtections(p *gl.Project, branches []*gl.ProtectedBranch, premi
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 	projName := projectResourceName(p)
+	names := branchProtectionResourceNames(p, branches)
 
 	for i, b := range branches {
 		if i > 0 {
 			rootBody.AppendNewline()
 		}
-		name := branchProtectionResourceName(p, b)
-		block := rootBody.AppendNewBlock("resource", []string{"gitlab_branch_protection", name})
+		block := rootBody.AppendNewBlock("resource", []string{"gitlab_branch_protection", names[i]})
 		body := block.Body()
 
 		body.SetAttributeTraversal("project", hcl.Traversal{

--- a/internal/terraform/branch_protections_test.go
+++ b/internal/terraform/branch_protections_test.go
@@ -33,6 +33,33 @@ func TestBranchProtectionResourceNameWildcard(t *testing.T) {
 	}
 }
 
+func TestBranchProtectionResourceNamesCollision(t *testing.T) {
+	project := &gl.Project{
+		Path:      "my-project",
+		Namespace: &gl.ProjectNamespace{FullPath: "my-group"},
+	}
+	// All three branch names normalize to the same base label and must stay unique.
+	branches := []*gl.ProtectedBranch{
+		{Name: "release.v1"},
+		{Name: "release-v1"},
+		{Name: "release_v1"},
+	}
+	got := branchProtectionResourceNames(project, branches)
+	want := []string{
+		"my_group_my_project_release_v1",
+		"my_group_my_project_release_v1_1",
+		"my_group_my_project_release_v1_2",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d names, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("names[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestWriteBranchProtections_Free(t *testing.T) {
 	project := &gl.Project{
 		ID:                1,

--- a/internal/terraform/hcl_string.go
+++ b/internal/terraform/hcl_string.go
@@ -1,0 +1,18 @@
+package terraform
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// hclString renders s as a safely-quoted, escaped HCL string literal (including
+// the surrounding quotes), using hclwrite's encoder.
+//
+// The template-based writers (labels, memberships, pipeline schedules) build HCL
+// with fmt.Fprintf. Interpolating a raw value into "%s" breaks the output when
+// the value contains a quote, newline, or ${...} interpolation sequence (e.g. a
+// label or schedule description, or a CI variable value). Wrapping such values
+// in hclString produces a correct literal for any input.
+func hclString(s string) string {
+	return string(hclwrite.TokensForValue(cty.StringVal(s)).Bytes())
+}

--- a/internal/terraform/hcl_string_test.go
+++ b/internal/terraform/hcl_string_test.go
@@ -1,0 +1,39 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// hclString must produce a literal that parses back to the exact original
+// string for any input — quotes, newlines, tabs, backslashes, and ${...}
+// interpolation sequences included.
+func TestHCLString_RoundTrips(t *testing.T) {
+	inputs := []string{
+		"plain",
+		`he said "hi"`,
+		"line1\nline2",
+		"${var.x}",
+		"tab\tend",
+		`back\slash`,
+		"",
+	}
+	for _, in := range inputs {
+		lit := hclString(in)
+		expr, diags := hclsyntax.ParseExpression([]byte(lit), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Errorf("hclString(%q) = %q is not parseable: %v", in, lit, diags)
+			continue
+		}
+		v, diags := expr.Value(nil)
+		if diags.HasErrors() {
+			t.Errorf("hclString(%q) = %q did not evaluate: %v", in, lit, diags)
+			continue
+		}
+		if v.AsString() != in {
+			t.Errorf("round-trip of %q via %q gave %q", in, lit, v.AsString())
+		}
+	}
+}

--- a/internal/terraform/hooks.go
+++ b/internal/terraform/hooks.go
@@ -28,21 +28,17 @@ func groupHookResourceName(g *gl.Group, h *gl.GroupHook) string {
 // projectHookResourceNames returns deterministic, collision-free terraform
 // resource names for one project's hooks.
 func projectHookResourceNames(p *gl.Project, hooks []*gl.ProjectHook) []string {
-	bases := make([]string, len(hooks))
-	for i, h := range hooks {
-		bases[i] = projectHookResourceName(p, h)
-	}
-	return dedupeResourceNames(bases)
+	return buildResourceNames(hooks, func(h *gl.ProjectHook) string {
+		return projectHookResourceName(p, h)
+	})
 }
 
 // groupHookResourceNames returns deterministic, collision-free terraform
 // resource names for one group's hooks.
 func groupHookResourceNames(g *gl.Group, hooks []*gl.GroupHook) []string {
-	bases := make([]string, len(hooks))
-	for i, h := range hooks {
-		bases[i] = groupHookResourceName(g, h)
-	}
-	return dedupeResourceNames(bases)
+	return buildResourceNames(hooks, func(h *gl.GroupHook) string {
+		return groupHookResourceName(g, h)
+	})
 }
 
 func WriteProjectHooks(p *gl.Project, hooks []*gl.ProjectHook, w io.Writer) error {

--- a/internal/terraform/hooks.go
+++ b/internal/terraform/hooks.go
@@ -25,17 +25,37 @@ func groupHookResourceName(g *gl.Group, h *gl.GroupHook) string {
 	return normalizeToTerraformName(g.Path) + "_" + normalizeHookURL(h.URL)
 }
 
+// projectHookResourceNames returns deterministic, collision-free terraform
+// resource names for one project's hooks.
+func projectHookResourceNames(p *gl.Project, hooks []*gl.ProjectHook) []string {
+	bases := make([]string, len(hooks))
+	for i, h := range hooks {
+		bases[i] = projectHookResourceName(p, h)
+	}
+	return dedupeResourceNames(bases)
+}
+
+// groupHookResourceNames returns deterministic, collision-free terraform
+// resource names for one group's hooks.
+func groupHookResourceNames(g *gl.Group, hooks []*gl.GroupHook) []string {
+	bases := make([]string, len(hooks))
+	for i, h := range hooks {
+		bases[i] = groupHookResourceName(g, h)
+	}
+	return dedupeResourceNames(bases)
+}
+
 func WriteProjectHooks(p *gl.Project, hooks []*gl.ProjectHook, w io.Writer) error {
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 	projName := projectResourceName(p)
+	names := projectHookResourceNames(p, hooks)
 
 	for i, h := range hooks {
 		if i > 0 {
 			rootBody.AppendNewline()
 		}
-		name := projectHookResourceName(p, h)
-		block := rootBody.AppendNewBlock("resource", []string{"gitlab_project_hook", name})
+		block := rootBody.AppendNewBlock("resource", []string{"gitlab_project_hook", names[i]})
 		body := block.Body()
 
 		body.SetAttributeTraversal("project", hcl.Traversal{
@@ -81,13 +101,13 @@ func WriteGroupHooks(g *gl.Group, hooks []*gl.GroupHook, w io.Writer) error {
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 	groupName := normalizeToTerraformName(g.Path)
+	names := groupHookResourceNames(g, hooks)
 
 	for i, h := range hooks {
 		if i > 0 {
 			rootBody.AppendNewline()
 		}
-		name := groupHookResourceName(g, h)
-		block := rootBody.AppendNewBlock("resource", []string{"gitlab_group_hook", name})
+		block := rootBody.AppendNewBlock("resource", []string{"gitlab_group_hook", names[i]})
 		body := block.Body()
 
 		body.SetAttributeTraversal("group", hcl.Traversal{

--- a/internal/terraform/hooks_test.go
+++ b/internal/terraform/hooks_test.go
@@ -25,6 +25,52 @@ func TestNormalizeHookURL(t *testing.T) {
 	}
 }
 
+func TestProjectHookResourceNamesCollision(t *testing.T) {
+	project := &gl.Project{
+		Path:      "my-project",
+		Namespace: &gl.ProjectNamespace{FullPath: "my-group"},
+	}
+	// Both URLs normalize to the same label and must stay unique.
+	hooks := []*gl.ProjectHook{
+		{URL: "https://example.com:8080/hook"},
+		{URL: "https://example.com/8080/hook"},
+	}
+	got := projectHookResourceNames(project, hooks)
+	want := []string{
+		"my_group_my_project_example_com_8080_hook",
+		"my_group_my_project_example_com_8080_hook_1",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d names, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("names[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestGroupHookResourceNamesCollision(t *testing.T) {
+	group := &gl.Group{Path: "my-group"}
+	hooks := []*gl.GroupHook{
+		{URL: "https://example.com:8080/hook"},
+		{URL: "https://example.com/8080/hook"},
+	}
+	got := groupHookResourceNames(group, hooks)
+	want := []string{
+		"my_group_example_com_8080_hook",
+		"my_group_example_com_8080_hook_1",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d names, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("names[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestWriteProjectHooks(t *testing.T) {
 	project := &gl.Project{
 		ID:                1,

--- a/internal/terraform/import.go
+++ b/internal/terraform/import.go
@@ -251,8 +251,10 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 			if p == nil {
 				continue
 			}
-			for _, s := range resources.PipelineSchedules[p.ID] {
-				schedName := pipelineScheduleResourceName(p, s)
+			schedules := resources.PipelineSchedules[p.ID]
+			schedNames := pipelineScheduleResourceNames(p, schedules)
+			for i, s := range schedules {
+				schedName := schedNames[i]
 				schedKey := "gitlab_pipeline_schedule." + schedName
 				if !existingResources[schedKey] {
 					cmds = append(cmds, ImportCommand{
@@ -260,9 +262,9 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 						ID:      fmt.Sprintf("%d:%d", p.ID, s.ID),
 					})
 				}
-				for _, v := range s.Variables {
-					varName := pipelineScheduleVariableResourceName(p, s, v)
-					varKey := "gitlab_pipeline_schedule_variable." + varName
+				varNames := pipelineScheduleVariableResourceNames(schedName, s.Variables)
+				for j, v := range s.Variables {
+					varKey := "gitlab_pipeline_schedule_variable." + varNames[j]
 					if !existingResources[varKey] {
 						cmds = append(cmds, ImportCommand{
 							Address: varKey,

--- a/internal/terraform/import.go
+++ b/internal/terraform/import.go
@@ -286,11 +286,20 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 // PrintImportCommands writes terraform import commands to w.
 func PrintImportCommands(w io.Writer, cmds []ImportCommand) error {
 	for _, cmd := range cmds {
-		if _, err := fmt.Fprintf(w, "terraform import '%s' '%s'\n", cmd.Address, cmd.ID); err != nil {
+		if _, err := fmt.Fprintf(w, "terraform import %s %s\n", shellSingleQuote(cmd.Address), shellSingleQuote(cmd.ID)); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// shellSingleQuote wraps s as a single POSIX shell word, escaping any embedded
+// single quote as '\'' (close, escaped-quote, reopen). The import IDs and
+// addresses embed raw GitLab data (branch/tag names, usernames, ...) that an
+// operator pastes into a shell, so a value containing a single quote must not
+// be able to break out of the quoting and execute injected commands.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // projectResourceName computes the terraform resource name for a project,

--- a/internal/terraform/import.go
+++ b/internal/terraform/import.go
@@ -126,9 +126,10 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 			if g == nil {
 				continue
 			}
-			for _, v := range resources.GroupVariables[g.ID] {
-				name := groupVariableResourceName(g, v)
-				key := "gitlab_group_variable." + name
+			vars := resources.GroupVariables[g.ID]
+			names := groupVariableResourceNames(g, vars)
+			for i, v := range vars {
+				key := "gitlab_group_variable." + names[i]
 				if !existingResources[key] {
 					cmds = append(cmds, ImportCommand{
 						Address: key,
@@ -142,9 +143,10 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 			if p == nil {
 				continue
 			}
-			for _, v := range resources.ProjectVariables[p.ID] {
-				name := projectVariableResourceName(p, v)
-				key := "gitlab_project_variable." + name
+			vars := resources.ProjectVariables[p.ID]
+			names := projectVariableResourceNames(p, vars)
+			for i, v := range vars {
+				key := "gitlab_project_variable." + names[i]
 				if !existingResources[key] {
 					cmds = append(cmds, ImportCommand{
 						Address: key,

--- a/internal/terraform/import.go
+++ b/internal/terraform/import.go
@@ -160,9 +160,10 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 			if p == nil {
 				continue
 			}
-			for _, b := range resources.ProtectedBranches[p.ID] {
-				name := branchProtectionResourceName(p, b)
-				key := "gitlab_branch_protection." + name
+			branches := resources.ProtectedBranches[p.ID]
+			names := branchProtectionResourceNames(p, branches)
+			for i, b := range branches {
+				key := "gitlab_branch_protection." + names[i]
 				if !existingResources[key] {
 					cmds = append(cmds, ImportCommand{
 						Address: key,

--- a/internal/terraform/import.go
+++ b/internal/terraform/import.go
@@ -198,9 +198,10 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 			if g == nil {
 				continue
 			}
-			for _, h := range resources.GroupHooks[g.ID] {
-				name := groupHookResourceName(g, h)
-				key := "gitlab_group_hook." + name
+			hooks := resources.GroupHooks[g.ID]
+			names := groupHookResourceNames(g, hooks)
+			for i, h := range hooks {
+				key := "gitlab_group_hook." + names[i]
 				if !existingResources[key] {
 					cmds = append(cmds, ImportCommand{
 						Address: key,
@@ -214,9 +215,10 @@ func GenerateImportCommands(resources *gitlab.Resources, existingResources map[s
 			if p == nil {
 				continue
 			}
-			for _, h := range resources.ProjectHooks[p.ID] {
-				name := projectHookResourceName(p, h)
-				key := "gitlab_project_hook." + name
+			hooks := resources.ProjectHooks[p.ID]
+			names := projectHookResourceNames(p, hooks)
+			for i, h := range hooks {
+				key := "gitlab_project_hook." + names[i]
 				if !existingResources[key] {
 					cmds = append(cmds, ImportCommand{
 						Address: key,

--- a/internal/terraform/import_test.go
+++ b/internal/terraform/import_test.go
@@ -349,6 +349,25 @@ func TestPrintImportCommands(t *testing.T) {
 	}
 }
 
+func TestPrintImportCommands_EscapesSingleQuotes(t *testing.T) {
+	// A branch/tag name (embedded raw in the import ID) can contain a single
+	// quote; the emitted shell line must not let it break out of the
+	// single-quoted argument when an operator pastes it into a shell.
+	cmds := []ImportCommand{
+		{Address: "gitlab_branch_protection.proj_main", ID: `1:x'; touch pwned #`},
+	}
+
+	var buf bytes.Buffer
+	if err := PrintImportCommands(&buf, cmds); err != nil {
+		t.Fatalf("PrintImportCommands error: %v", err)
+	}
+
+	want := `terraform import 'gitlab_branch_protection.proj_main' '1:x'\''; touch pwned #'` + "\n"
+	if buf.String() != want {
+		t.Errorf("single quote not safely escaped:\ngot:  %s\nwant: %s", buf.String(), want)
+	}
+}
+
 func TestGenerateImportCommandsNewPipelineSchedule(t *testing.T) {
 	resources := &gitlab.Resources{
 		Projects: []*gl.Project{

--- a/internal/terraform/labels.go
+++ b/internal/terraform/labels.go
@@ -25,11 +25,11 @@ func WriteGroupLabelVariable(groups []*gl.Group, groupLabels gitlab.GroupLabels,
 		if len(labels) == 0 {
 			continue
 		}
-		fmt.Fprintf(&b, "    \"%s\" = {\n", g.FullPath)
+		fmt.Fprintf(&b, "    %s = {\n", hclString(g.FullPath))
 		for _, l := range labels {
-			fmt.Fprintf(&b, "      \"%s\" = {\n", l.Name)
-			fmt.Fprintf(&b, "        color       = \"%s\"\n", l.Color)
-			fmt.Fprintf(&b, "        description = \"%s\"\n", l.Description)
+			fmt.Fprintf(&b, "      %s = {\n", hclString(l.Name))
+			fmt.Fprintf(&b, "        color       = %s\n", hclString(l.Color))
+			fmt.Fprintf(&b, "        description = %s\n", hclString(l.Description))
 			b.WriteString("      }\n")
 		}
 		b.WriteString("    }\n")
@@ -70,11 +70,11 @@ func WriteProjectLabelVariable(projects []*gl.Project, projectLabels gitlab.Proj
 		if len(labels) == 0 {
 			continue
 		}
-		fmt.Fprintf(&b, "    \"%s\" = {\n", path)
+		fmt.Fprintf(&b, "    %s = {\n", hclString(path))
 		for _, l := range labels {
-			fmt.Fprintf(&b, "      \"%s\" = {\n", l.Name)
-			fmt.Fprintf(&b, "        color       = \"%s\"\n", l.Color)
-			fmt.Fprintf(&b, "        description = \"%s\"\n", l.Description)
+			fmt.Fprintf(&b, "      %s = {\n", hclString(l.Name))
+			fmt.Fprintf(&b, "        color       = %s\n", hclString(l.Color))
+			fmt.Fprintf(&b, "        description = %s\n", hclString(l.Description))
 			b.WriteString("      }\n")
 		}
 		b.WriteString("    }\n")

--- a/internal/terraform/pipeline_schedules.go
+++ b/internal/terraform/pipeline_schedules.go
@@ -58,13 +58,13 @@ func WritePipelineSchedules(p *gl.Project, schedules []*gl.PipelineSchedule, w i
 		}
 		if _, err := fmt.Fprintf(w, `resource "gitlab_pipeline_schedule" "%s" {
   project       = gitlab_project.%s.id
-  description   = "%s"
-  ref           = "%s"
-  cron          = "%s"
-  cron_timezone = "%s"
+  description   = %s
+  ref           = %s
+  cron          = %s
+  cron_timezone = %s
   active        = %t
 }
-`, schedName, projName, s.Description, s.Ref, s.Cron, s.CronTimezone, s.Active); err != nil {
+`, schedName, projName, hclString(s.Description), hclString(s.Ref), hclString(s.Cron), hclString(s.CronTimezone), s.Active); err != nil {
 			return err
 		}
 
@@ -74,11 +74,11 @@ func WritePipelineSchedules(p *gl.Project, schedules []*gl.PipelineSchedule, w i
 resource "gitlab_pipeline_schedule_variable" "%s" {
   project              = gitlab_project.%s.id
   pipeline_schedule_id = gitlab_pipeline_schedule.%s.pipeline_schedule_id
-  key                  = "%s"
-  value                = "%s"
-  variable_type        = "%s"
+  key                  = %s
+  value                = %s
+  variable_type        = %s
 }
-`, varNames[j], projName, schedName, v.Key, v.Value, string(v.VariableType)); err != nil {
+`, varNames[j], projName, schedName, hclString(v.Key), hclString(v.Value), hclString(string(v.VariableType))); err != nil {
 				return err
 			}
 		}

--- a/internal/terraform/pipeline_schedules.go
+++ b/internal/terraform/pipeline_schedules.go
@@ -25,14 +25,32 @@ func pipelineScheduleResourceName(p *gl.Project, s *gl.PipelineSchedule) string 
 	return projectResourceName(p) + "_" + normalizeName(s.Description)
 }
 
-func pipelineScheduleVariableResourceName(p *gl.Project, s *gl.PipelineSchedule, v *gl.PipelineVariable) string {
-	return pipelineScheduleResourceName(p, s) + "_" + normalizeName(v.Key)
+// pipelineScheduleResourceNames returns deterministic, collision-free terraform
+// resource names for one project's pipeline schedules.
+func pipelineScheduleResourceNames(p *gl.Project, schedules []*gl.PipelineSchedule) []string {
+	bases := make([]string, len(schedules))
+	for i, s := range schedules {
+		bases[i] = pipelineScheduleResourceName(p, s)
+	}
+	return dedupeResourceNames(bases)
+}
+
+// pipelineScheduleVariableResourceNames returns deterministic, collision-free
+// terraform resource names for one schedule's variables, prefixed with the
+// schedule's already-deduped resource name.
+func pipelineScheduleVariableResourceNames(schedName string, vars []*gl.PipelineVariable) []string {
+	bases := make([]string, len(vars))
+	for i, v := range vars {
+		bases[i] = schedName + "_" + normalizeName(v.Key)
+	}
+	return dedupeResourceNames(bases)
 }
 
 func WritePipelineSchedules(p *gl.Project, schedules []*gl.PipelineSchedule, w io.Writer) error {
 	projName := projectResourceName(p)
+	schedNames := pipelineScheduleResourceNames(p, schedules)
 	for i, s := range schedules {
-		schedName := pipelineScheduleResourceName(p, s)
+		schedName := schedNames[i]
 		if i > 0 {
 			if _, err := fmt.Fprint(w, "\n"); err != nil {
 				return err
@@ -50,8 +68,8 @@ func WritePipelineSchedules(p *gl.Project, schedules []*gl.PipelineSchedule, w i
 			return err
 		}
 
-		for _, v := range s.Variables {
-			varName := pipelineScheduleVariableResourceName(p, s, v)
+		varNames := pipelineScheduleVariableResourceNames(schedName, s.Variables)
+		for j, v := range s.Variables {
 			if _, err := fmt.Fprintf(w, `
 resource "gitlab_pipeline_schedule_variable" "%s" {
   project              = gitlab_project.%s.id
@@ -60,7 +78,7 @@ resource "gitlab_pipeline_schedule_variable" "%s" {
   value                = "%s"
   variable_type        = "%s"
 }
-`, varName, projName, schedName, v.Key, v.Value, string(v.VariableType)); err != nil {
+`, varNames[j], projName, schedName, v.Key, v.Value, string(v.VariableType)); err != nil {
 				return err
 			}
 		}

--- a/internal/terraform/pipeline_schedules.go
+++ b/internal/terraform/pipeline_schedules.go
@@ -9,10 +9,19 @@ import (
 )
 
 func normalizeName(s string) string {
-	normalized := strings.ToLower(s)
-	for _, ch := range []string{"/", "-", " ", "."} {
-		normalized = strings.ReplaceAll(normalized, ch, "_")
-	}
+	// Lowercase, then replace every character that is not valid in a terraform
+	// identifier ([a-z0-9_]) with an underscore. This covers the common
+	// separators (/ - space .) as well as anything else a free-text GitLab field
+	// might contain (quotes, $, {, (, :, ', ...), which would otherwise produce
+	// an invalid resource label.
+	normalized := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_':
+			return r
+		default:
+			return '_'
+		}
+	}, strings.ToLower(s))
 	// Collapse consecutive underscores.
 	for strings.Contains(normalized, "__") {
 		normalized = strings.ReplaceAll(normalized, "__", "_")

--- a/internal/terraform/pipeline_schedules.go
+++ b/internal/terraform/pipeline_schedules.go
@@ -37,22 +37,18 @@ func pipelineScheduleResourceName(p *gl.Project, s *gl.PipelineSchedule) string 
 // pipelineScheduleResourceNames returns deterministic, collision-free terraform
 // resource names for one project's pipeline schedules.
 func pipelineScheduleResourceNames(p *gl.Project, schedules []*gl.PipelineSchedule) []string {
-	bases := make([]string, len(schedules))
-	for i, s := range schedules {
-		bases[i] = pipelineScheduleResourceName(p, s)
-	}
-	return dedupeResourceNames(bases)
+	return buildResourceNames(schedules, func(s *gl.PipelineSchedule) string {
+		return pipelineScheduleResourceName(p, s)
+	})
 }
 
 // pipelineScheduleVariableResourceNames returns deterministic, collision-free
 // terraform resource names for one schedule's variables, prefixed with the
 // schedule's already-deduped resource name.
 func pipelineScheduleVariableResourceNames(schedName string, vars []*gl.PipelineVariable) []string {
-	bases := make([]string, len(vars))
-	for i, v := range vars {
-		bases[i] = schedName + "_" + normalizeName(v.Key)
-	}
-	return dedupeResourceNames(bases)
+	return buildResourceNames(vars, func(v *gl.PipelineVariable) string {
+		return schedName + "_" + normalizeName(v.Key)
+	})
 }
 
 func WritePipelineSchedules(p *gl.Project, schedules []*gl.PipelineSchedule, w io.Writer) error {

--- a/internal/terraform/pipeline_schedules_test.go
+++ b/internal/terraform/pipeline_schedules_test.go
@@ -105,6 +105,12 @@ func TestNormalizeName(t *testing.T) {
 		{"a--b//c  d..e", "a_b_c_d_e"},
 		{"trailing-", "trailing"},
 		{"DEPLOY_ENV", "deploy_env"},
+		// Characters illegal in a terraform identifier must be sanitized, not
+		// passed through (which would produce an invalid resource label).
+		{`P1: "critical"`, "p1_critical"},
+		{"deploy (prod)!", "deploy_prod"},
+		{"a${b}", "a_b"},
+		{"won't fix", "won_t_fix"},
 	}
 	for _, tt := range tests {
 		got := normalizeName(tt.input)

--- a/internal/terraform/pipeline_schedules_test.go
+++ b/internal/terraform/pipeline_schedules_test.go
@@ -45,6 +45,54 @@ func TestWritePipelineSchedules(t *testing.T) {
 	compareGolden(t, "pipeline_schedules.tf", buf.String())
 }
 
+func TestPipelineScheduleResourceNamesCollision(t *testing.T) {
+	project := &gl.Project{
+		Path:      "my-project",
+		Namespace: &gl.ProjectNamespace{FullPath: "my-group"},
+	}
+	// All three descriptions normalize to the same base label and must stay unique.
+	schedules := []*gl.PipelineSchedule{
+		{Description: "Nightly build"},
+		{Description: "nightly-build"},
+		{Description: "nightly.build"},
+	}
+	got := pipelineScheduleResourceNames(project, schedules)
+	want := []string{
+		"my_group_my_project_nightly_build",
+		"my_group_my_project_nightly_build_1",
+		"my_group_my_project_nightly_build_2",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d names, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("names[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPipelineScheduleVariableResourceNamesCollision(t *testing.T) {
+	// Two variable keys within one schedule normalize to the same label.
+	vars := []*gl.PipelineVariable{
+		{Key: "DEPLOY_ENV"},
+		{Key: "deploy-env"},
+	}
+	got := pipelineScheduleVariableResourceNames("my_group_my_project_nightly_build", vars)
+	want := []string{
+		"my_group_my_project_nightly_build_deploy_env",
+		"my_group_my_project_nightly_build_deploy_env_1",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d names, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("names[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestNormalizeName(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/terraform/resource_names.go
+++ b/internal/terraform/resource_names.go
@@ -1,0 +1,26 @@
+package terraform
+
+import "fmt"
+
+// dedupeResourceNames returns collision-free terraform resource names for a list
+// of sibling resources, preserving order. Distinct source values can normalize to
+// the same label (e.g. "v1.0" and "v1-0" both become "v1_0"); the second and later
+// entries that share a base get a numeric suffix (_1, _2, ...) so every resource
+// address stays unique. Names that do not collide are returned unchanged, so
+// existing terraform addresses never shift.
+//
+// The writer and the import generator must build base names the same way and pass
+// the same slice so the names they emit agree.
+func dedupeResourceNames(bases []string) []string {
+	names := make([]string, len(bases))
+	used := make(map[string]bool, len(bases))
+	for i, base := range bases {
+		name := base
+		for n := 1; used[name]; n++ {
+			name = fmt.Sprintf("%s_%d", base, n)
+		}
+		used[name] = true
+		names[i] = name
+	}
+	return names
+}

--- a/internal/terraform/resource_names.go
+++ b/internal/terraform/resource_names.go
@@ -11,6 +11,19 @@ import "fmt"
 //
 // The writer and the import generator must build base names the same way and pass
 // the same slice so the names they emit agree.
+// buildResourceNames maps each item to a base name via name, then returns
+// collision-free names via dedupeResourceNames. It removes the repeated
+// "allocate a bases slice, loop, dedupe" boilerplate from the per-resource
+// xResourceNames functions, so a new resource type only needs its singular
+// name function.
+func buildResourceNames[T any](items []T, name func(T) string) []string {
+	bases := make([]string, len(items))
+	for i, item := range items {
+		bases[i] = name(item)
+	}
+	return dedupeResourceNames(bases)
+}
+
 func dedupeResourceNames(bases []string) []string {
 	names := make([]string, len(bases))
 	used := make(map[string]bool, len(bases))

--- a/internal/terraform/resource_names_test.go
+++ b/internal/terraform/resource_names_test.go
@@ -1,0 +1,35 @@
+package terraform
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestDedupeResourceNames_NoCollisionsUnchanged(t *testing.T) {
+	// The hard constraint: names that don't collide must be returned byte-for-byte
+	// unchanged, so existing terraform addresses never shift.
+	in := []string{"alpha", "beta", "gamma"}
+	got := dedupeResourceNames(in)
+	want := []string{"alpha", "beta", "gamma"}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestDedupeResourceNames_CollisionsSuffixed(t *testing.T) {
+	in := []string{"v1_0", "v1_0", "v1_0"}
+	got := dedupeResourceNames(in)
+	want := []string{"v1_0", "v1_0_1", "v1_0_2"}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestDedupeResourceNames_MixedCollisions(t *testing.T) {
+	in := []string{"a", "b", "a", "a", "b"}
+	got := dedupeResourceNames(in)
+	want := []string{"a", "b", "a_1", "a_2", "b_1"}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/internal/terraform/tag_protections.go
+++ b/internal/terraform/tag_protections.go
@@ -16,11 +16,9 @@ func tagProtectionResourceName(p *gl.Project, t *gl.ProtectedTag) string {
 // tagProtectionResourceNames returns deterministic, collision-free terraform
 // resource names for one project's protected tags.
 func tagProtectionResourceNames(p *gl.Project, tags []*gl.ProtectedTag) []string {
-	bases := make([]string, len(tags))
-	for i, t := range tags {
-		bases[i] = tagProtectionResourceName(p, t)
-	}
-	return dedupeResourceNames(bases)
+	return buildResourceNames(tags, func(t *gl.ProtectedTag) string {
+		return tagProtectionResourceName(p, t)
+	})
 }
 
 func isBaseTagAccessLevel(l *gl.TagAccessDescription) bool {

--- a/internal/terraform/tag_protections.go
+++ b/internal/terraform/tag_protections.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/hashicorp/hcl/v2"
@@ -15,24 +14,13 @@ func tagProtectionResourceName(p *gl.Project, t *gl.ProtectedTag) string {
 }
 
 // tagProtectionResourceNames returns deterministic, collision-free terraform
-// resource names for one project's protected tags. Distinct tag names can
-// normalize to the same label (e.g. "v1.0" and "v1-0" both become "v1_0"); the
-// second and later collisions get a numeric suffix so every block stays unique.
-// The writer and the import generator must call this with the same tag slice so
-// the names they emit agree.
+// resource names for one project's protected tags.
 func tagProtectionResourceNames(p *gl.Project, tags []*gl.ProtectedTag) []string {
-	names := make([]string, len(tags))
-	used := make(map[string]bool, len(tags))
+	bases := make([]string, len(tags))
 	for i, t := range tags {
-		base := tagProtectionResourceName(p, t)
-		name := base
-		for n := 1; used[name]; n++ {
-			name = fmt.Sprintf("%s_%d", base, n)
-		}
-		used[name] = true
-		names[i] = name
+		bases[i] = tagProtectionResourceName(p, t)
 	}
-	return names
+	return dedupeResourceNames(bases)
 }
 
 func isBaseTagAccessLevel(l *gl.TagAccessDescription) bool {

--- a/internal/terraform/variables.go
+++ b/internal/terraform/variables.go
@@ -25,6 +25,26 @@ func projectVariableResourceName(p *gl.Project, v *gl.ProjectVariable) string {
 	return variableResourceName(projectResourceName(p), v.Key, v.EnvironmentScope)
 }
 
+// groupVariableResourceNames returns deterministic, collision-free terraform
+// resource names for one group's variables.
+func groupVariableResourceNames(g *gl.Group, vars []*gl.GroupVariable) []string {
+	bases := make([]string, len(vars))
+	for i, v := range vars {
+		bases[i] = groupVariableResourceName(g, v)
+	}
+	return dedupeResourceNames(bases)
+}
+
+// projectVariableResourceNames returns deterministic, collision-free terraform
+// resource names for one project's variables.
+func projectVariableResourceNames(p *gl.Project, vars []*gl.ProjectVariable) []string {
+	bases := make([]string, len(vars))
+	for i, v := range vars {
+		bases[i] = projectVariableResourceName(p, v)
+	}
+	return dedupeResourceNames(bases)
+}
+
 func writeVariableAttrs(body *hclwrite.Body, key, value, varType, envScope, description string, protected, raw bool) {
 	body.SetAttributeValue("key", cty.StringVal(key))
 	body.SetAttributeValue("value", cty.StringVal(value))
@@ -43,13 +63,13 @@ func WriteGroupVariables(g *gl.Group, vars []*gl.GroupVariable, w io.Writer) err
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 	groupName := normalizeToTerraformName(g.Path)
+	names := groupVariableResourceNames(g, vars)
 
 	for i, v := range vars {
 		if i > 0 {
 			rootBody.AppendNewline()
 		}
-		name := groupVariableResourceName(g, v)
-		block := rootBody.AppendNewBlock("resource", []string{"gitlab_group_variable", name})
+		block := rootBody.AppendNewBlock("resource", []string{"gitlab_group_variable", names[i]})
 		body := block.Body()
 
 		body.SetAttributeTraversal("group", hcl.Traversal{
@@ -68,13 +88,13 @@ func WriteProjectVariables(p *gl.Project, vars []*gl.ProjectVariable, w io.Write
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 	projName := projectResourceName(p)
+	names := projectVariableResourceNames(p, vars)
 
 	for i, v := range vars {
 		if i > 0 {
 			rootBody.AppendNewline()
 		}
-		name := projectVariableResourceName(p, v)
-		block := rootBody.AppendNewBlock("resource", []string{"gitlab_project_variable", name})
+		block := rootBody.AppendNewBlock("resource", []string{"gitlab_project_variable", names[i]})
 		body := block.Body()
 
 		body.SetAttributeTraversal("project", hcl.Traversal{

--- a/internal/terraform/variables.go
+++ b/internal/terraform/variables.go
@@ -28,21 +28,17 @@ func projectVariableResourceName(p *gl.Project, v *gl.ProjectVariable) string {
 // groupVariableResourceNames returns deterministic, collision-free terraform
 // resource names for one group's variables.
 func groupVariableResourceNames(g *gl.Group, vars []*gl.GroupVariable) []string {
-	bases := make([]string, len(vars))
-	for i, v := range vars {
-		bases[i] = groupVariableResourceName(g, v)
-	}
-	return dedupeResourceNames(bases)
+	return buildResourceNames(vars, func(v *gl.GroupVariable) string {
+		return groupVariableResourceName(g, v)
+	})
 }
 
 // projectVariableResourceNames returns deterministic, collision-free terraform
 // resource names for one project's variables.
 func projectVariableResourceNames(p *gl.Project, vars []*gl.ProjectVariable) []string {
-	bases := make([]string, len(vars))
-	for i, v := range vars {
-		bases[i] = projectVariableResourceName(p, v)
-	}
-	return dedupeResourceNames(bases)
+	return buildResourceNames(vars, func(v *gl.ProjectVariable) string {
+		return projectVariableResourceName(p, v)
+	})
 }
 
 func writeVariableAttrs(body *hclwrite.Body, key, value, varType, envScope, description string, protected, raw bool) {

--- a/internal/terraform/variables_test.go
+++ b/internal/terraform/variables_test.go
@@ -82,3 +82,43 @@ func TestGroupVariableResourceName(t *testing.T) {
 		}
 	}
 }
+
+func TestGroupVariableResourceNamesCollision(t *testing.T) {
+	group := &gl.Group{Path: "my-group"}
+	// Both keys normalize to the same label and must stay unique.
+	vars := []*gl.GroupVariable{
+		{Key: "MY.KEY", EnvironmentScope: "*"},
+		{Key: "MY-KEY", EnvironmentScope: "*"},
+	}
+	got := groupVariableResourceNames(group, vars)
+	want := []string{"my_group_my_key", "my_group_my_key_1"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d names, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("names[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestProjectVariableResourceNamesCollision(t *testing.T) {
+	project := &gl.Project{
+		Path:      "my-project",
+		Namespace: &gl.ProjectNamespace{FullPath: "my-group"},
+	}
+	vars := []*gl.ProjectVariable{
+		{Key: "MY.KEY", EnvironmentScope: "*"},
+		{Key: "MY-KEY", EnvironmentScope: "*"},
+	}
+	got := projectVariableResourceNames(project, vars)
+	want := []string{"my_group_my_project_my_key", "my_group_my_project_my_key_1"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d names, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("names[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/terraform/writers_escaping_test.go
+++ b/internal/terraform/writers_escaping_test.go
@@ -27,14 +27,16 @@ func TestWritePipelineSchedules_EscapesSpecialChars(t *testing.T) {
 	}
 	schedules := []*gl.PipelineSchedule{
 		{
-			ID:           10,
-			Description:  "Nightly build", // safe: also used as the resource name
-			Ref:          "main",
-			Cron:         "0 2 * * *",
-			CronTimezone: "Europe/Vienna",
-			Active:       true,
+			ID: 10,
+			// Special chars here exercise both fixes at once: the resource name
+			// (sanitized by normalizeName) and the description value (escaped by
+			// hclString).
+			Description:   `nightly "build" ${env}`,
+			Ref:           "main",
+			Cron:          "0 2 * * *",
+			CronTimezone:  "Europe/Vienna",
+			Active:        true,
 			Variables: []*gl.PipelineVariable{
-				// A CI variable value is free text and not part of any name.
 				{Key: "MSG", Value: `say "hi"` + "\nline2 ${x}", VariableType: "env_var"},
 			},
 		},

--- a/internal/terraform/writers_escaping_test.go
+++ b/internal/terraform/writers_escaping_test.go
@@ -1,0 +1,61 @@
+package terraform
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/xMoelletschi/terraform-gitlab-drift/internal/gitlab"
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+func assertParseableHCL(t *testing.T, src string) {
+	t.Helper()
+	_, diags := hclsyntax.ParseConfig([]byte(src), "gen.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("generated HCL does not parse:\n%s\ndiagnostics: %v", src, diags)
+	}
+}
+
+func TestWritePipelineSchedules_EscapesSpecialChars(t *testing.T) {
+	project := &gl.Project{
+		ID:                1,
+		Path:              "my-project",
+		Namespace:         &gl.ProjectNamespace{FullPath: "my-group"},
+		PathWithNamespace: "my-group/my-project",
+	}
+	schedules := []*gl.PipelineSchedule{
+		{
+			ID:           10,
+			Description:  "Nightly build", // safe: also used as the resource name
+			Ref:          "main",
+			Cron:         "0 2 * * *",
+			CronTimezone: "Europe/Vienna",
+			Active:       true,
+			Variables: []*gl.PipelineVariable{
+				// A CI variable value is free text and not part of any name.
+				{Key: "MSG", Value: `say "hi"` + "\nline2 ${x}", VariableType: "env_var"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WritePipelineSchedules(project, schedules, &buf); err != nil {
+		t.Fatalf("WritePipelineSchedules error: %v", err)
+	}
+	assertParseableHCL(t, buf.String())
+}
+
+func TestWriteGroupLabelVariable_EscapesSpecialChars(t *testing.T) {
+	groups := []*gl.Group{{ID: 10, Path: "my-group", FullPath: "my-group"}}
+	groupLabels := gitlab.GroupLabels{
+		10: {{Name: `urgent "p1"`, Color: "#ff0000", Description: `fix ${now}`}},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteGroupLabelVariable(groups, groupLabels, &buf); err != nil {
+		t.Fatalf("WriteGroupLabelVariable error: %v", err)
+	}
+	assertParseableHCL(t, buf.String())
+}


### PR DESCRIPTION
## Overview

Foundation-hardening pass **before** adding new GitLab resource types — no new resource coverage. Focus: correctness, resilience, security, and lowering the friction of adding resources later. 17 commits.

**Golden tests are unchanged**, so emitted `.tf` is **byte-identical for safe inputs** — existing users' resource addresses don't shift.

## What's included

### Correctness
- **Collision-safe resource naming** — shared `dedupeResourceNames` + generic `buildResourceNames`, applied in **both** the writer and the import generator so addresses agree. Fixes duplicate-address `terraform plan` failures when two names normalize equal (e.g. `release.v1` vs `release-v1`). Covers branch/tag protections, hooks, variables, pipeline schedules.
- **Resource-name sanitization** — `normalizeName` now maps anything outside `[a-z0-9_]` to `_`, so a label `Won't fix`, a schedule description with punctuation, or a hook URL with a query string no longer yields an invalid terraform label.
- **HCL value escaping** — new `hclString` helper wraps free-text fields (descriptions, CI variable values, label names/colors) so quotes / newlines / `${...}` can't break or interpolate the emitted HCL.

### Resilience
- **Graceful 403/404** — a restricted, archived, or just-deleted project/subgroup is logged and skipped instead of aborting the whole scan (shared `skipInaccessible`, folded into the paginator).
- **`--timeout`** to bound total scan duration (default `0` = off).

### Security
- **Shell-escape the generated `terraform import` commands** — a branch/tag/label name containing `'` previously broke out of the single-quoted argument and could execute injected commands when an operator pasted the line. Both fields now go through `shellSingleQuote`.
- **Job-token scopes: skip the whole project** when an allowlist sub-fetch is inaccessible, instead of emitting a misleadingly-empty allowlist (which would read as drift and delete entries on apply).

### Refactor / extensibility
- Shared generic `paginate[T]` helper — removed ~12 duplicated page-cursor loops.
- Generic `buildResourceNames` so a new resource type only needs its singular name function.

### Features
- **Configurable filtering** via a `FilterConfig` struct (ready for a future config file): `--show-pending-deletion` (default hidden) and `--hide-archived` (default shown; archived exists only on projects in the API). Defaults preserve current behavior.

### Tests
- Backfilled previously-untested fetcher logic: pending-deletion/archived filtering, masked/hidden/file variable filtering, job-token self-dedup + composite-skip, pagination, 403/404 skip. HCL escaping round-trip + writer parse tests. Collision tests per resource.

## Verification
`go build -race`, `go vet`, `go test -race ./...`, and `golangci-lint run` — **all green (0 lint issues)**.

## Out of scope (follow-ups)
- **Phase 3** — parallelize `FetchAll` + `--concurrency` + rate limiter (performance). Separate branch/PR.
- `gitlab_group` / `gitlab_project` / labels collision dedup — documented in `MISSING_RESOURCES.md`.