### PR TITLE
Parallel resource fetching with a proactive rate limiter (Phase 3)

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -30,6 +30,8 @@ var (
 	scanTimeout         time.Duration
 	showPendingDeletion bool
 	hideArchived        bool
+	rateLimit           float64
+	concurrency         int
 )
 
 var scanCmd = &cobra.Command{
@@ -51,6 +53,8 @@ func init() {
 	scanCmd.Flags().DurationVar(&scanTimeout, "timeout", 0, "Maximum total scan duration (e.g. 30m); 0 disables the timeout")
 	scanCmd.Flags().BoolVar(&showPendingDeletion, "show-pending-deletion", false, "Include groups/projects in the deletion grace period (hidden by default)")
 	scanCmd.Flags().BoolVar(&hideArchived, "hide-archived", false, "Skip archived projects (shown by default)")
+	scanCmd.Flags().Float64Var(&rateLimit, "rate-limit", 10, "Max GitLab API requests per second (0 = unlimited). Conservative default avoids rate limits; raise for self-managed instances with more headroom")
+	scanCmd.Flags().IntVar(&concurrency, "concurrency", 10, "Max number of resource types fetched in parallel")
 }
 
 // withTimeout bounds ctx to d. A non-positive d returns ctx unchanged with a
@@ -105,7 +109,10 @@ func runScan(cmd *cobra.Command, args []string) error {
 		"create_mr", createMR,
 	)
 
-	client, err := gitlab.NewClient(token, gitlabURL, gitlabGroup)
+	client, err := gitlab.NewClient(token, gitlabURL, gitlabGroup, gitlab.ClientConfig{
+		RateLimit:   rateLimit,
+		Concurrency: concurrency,
+	})
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/zclconf/go-cty v1.18.1
 	gitlab.com/gitlab-org/api/client-go/v2 v2.32.0
 	go.uber.org/mock v0.6.0
+	golang.org/x/sync v0.20.0
+	golang.org/x/time v0.15.0
 )
 
 require (
@@ -22,8 +24,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
 )

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -7,11 +7,34 @@ import (
 
 	"github.com/xMoelletschi/terraform-gitlab-drift/internal/skip"
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
+	"golang.org/x/sync/errgroup"
 )
 
 type Client struct {
-	api   *gl.Client
-	group string
+	api         *gl.Client
+	group       string
+	concurrency int
+}
+
+// defaultConcurrency bounds how many resource fetchers run at once when the
+// caller does not specify a value.
+const defaultConcurrency = 10
+
+// ClientConfig tunes how the client talks to the GitLab API.
+type ClientConfig struct {
+	// RateLimit caps API requests per second via the client's proactive
+	// limiter. 0 disables the cap.
+	RateLimit float64
+	// Concurrency bounds how many resource fetchers run at once. <= 0 uses
+	// defaultConcurrency.
+	Concurrency int
+}
+
+func resolveConcurrency(n int) int {
+	if n <= 0 {
+		return defaultConcurrency
+	}
+	return n
 }
 
 type Resources struct {
@@ -31,121 +54,175 @@ type Resources struct {
 }
 
 func NewClientFromAPI(api *gl.Client, group string) *Client {
-	return &Client{api: api, group: group}
+	return &Client{api: api, group: group, concurrency: defaultConcurrency}
 }
 
-func NewClient(token, baseURL, group string) (*Client, error) {
-	client, err := gl.NewClient(token, gl.WithBaseURL(baseURL))
+func NewClient(token, baseURL, group string, cfg ClientConfig) (*Client, error) {
+	client, err := gl.NewClient(token,
+		gl.WithBaseURL(baseURL),
+		gl.WithCustomLimiter(newRateLimiter(cfg.RateLimit)),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("creating GitLab client: %w", err)
 	}
-	return &Client{api: client, group: group}, nil
+	return &Client{api: client, group: group, concurrency: resolveConcurrency(cfg.Concurrency)}, nil
 }
 
 func (c *Client) FetchAll(ctx context.Context, skipSet skip.Set, cfg FilterConfig) (*Resources, error) {
-	groups, err := c.ListGroups(ctx, cfg)
-	if err != nil {
-		return nil, fmt.Errorf("listing groups: %w", err)
+	// Groups and projects are needed by every subresource fetcher, so fetch
+	// them first — concurrently with each other.
+	var (
+		groups   []*gl.Group
+		projects []*gl.Project
+	)
+	pre, preCtx := errgroup.WithContext(ctx)
+	pre.Go(func() error {
+		var err error
+		if groups, err = c.ListGroups(preCtx, cfg); err != nil {
+			return fmt.Errorf("listing groups: %w", err)
+		}
+		return nil
+	})
+	pre.Go(func() error {
+		var err error
+		if projects, err = c.ListProjects(preCtx, cfg); err != nil {
+			return fmt.Errorf("listing projects: %w", err)
+		}
+		return nil
+	})
+	if err := pre.Wait(); err != nil {
+		return nil, err
 	}
 	slog.Info("fetched groups", "count", len(groups))
-
-	projects, err := c.ListProjects(ctx, cfg)
-	if err != nil {
-		return nil, fmt.Errorf("listing projects: %w", err)
-	}
 	slog.Info("fetched projects", "count", len(projects))
 
-	var groupMembers GroupMembers
+	// The subresource fetchers are independent and each writes its own result
+	// variable, so they run concurrently, bounded by c.concurrency. The client's
+	// rate limiter keeps the combined request rate under the API limit.
+	var (
+		groupMembers      GroupMembers
+		groupLabels       GroupLabels
+		projectLabels     ProjectLabels
+		pipelineSchedules PipelineSchedules
+		projectHooks      ProjectHooks
+		groupHooks        GroupHooks
+		projectVariables  ProjectVariables
+		groupVariables    GroupVariables
+		protectedBranches ProtectedBranches
+		protectedTags     ProtectedTags
+		jobTokenScopes    JobTokenScopes
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(resolveConcurrency(c.concurrency))
+
 	if !skipSet.Has("memberships") {
-		groupMembers, err = c.ListGroupMembers(ctx, groups)
-		if err != nil {
-			return nil, fmt.Errorf("listing group members: %w", err)
-		}
-		slog.Info("fetched group members", "count", len(groupMembers))
+		g.Go(func() error {
+			var err error
+			if groupMembers, err = c.ListGroupMembers(gctx, groups); err != nil {
+				return fmt.Errorf("listing group members: %w", err)
+			}
+			slog.Info("fetched group members", "count", len(groupMembers))
+			return nil
+		})
 	}
-
-	var groupLabels GroupLabels
-	var projectLabels ProjectLabels
 	if !skipSet.Has("labels") {
-		groupLabels, err = c.ListGroupLabels(ctx, groups)
-		if err != nil {
-			return nil, fmt.Errorf("listing group labels: %w", err)
-		}
-		slog.Info("fetched group labels", "count", len(groupLabels))
-
-		projectLabels, err = c.ListProjectLabels(ctx, projects)
-		if err != nil {
-			return nil, fmt.Errorf("listing project labels: %w", err)
-		}
-		slog.Info("fetched project labels", "count", len(projectLabels))
+		g.Go(func() error {
+			var err error
+			if groupLabels, err = c.ListGroupLabels(gctx, groups); err != nil {
+				return fmt.Errorf("listing group labels: %w", err)
+			}
+			slog.Info("fetched group labels", "count", len(groupLabels))
+			return nil
+		})
+		g.Go(func() error {
+			var err error
+			if projectLabels, err = c.ListProjectLabels(gctx, projects); err != nil {
+				return fmt.Errorf("listing project labels: %w", err)
+			}
+			slog.Info("fetched project labels", "count", len(projectLabels))
+			return nil
+		})
 	}
-
-	var pipelineSchedules PipelineSchedules
 	if !skipSet.Has("schedules") {
-		pipelineSchedules, err = c.ListPipelineSchedules(ctx, projects)
-		if err != nil {
-			return nil, fmt.Errorf("listing pipeline schedules: %w", err)
-		}
-		slog.Info("fetched pipeline schedules", "count", len(pipelineSchedules))
+		g.Go(func() error {
+			var err error
+			if pipelineSchedules, err = c.ListPipelineSchedules(gctx, projects); err != nil {
+				return fmt.Errorf("listing pipeline schedules: %w", err)
+			}
+			slog.Info("fetched pipeline schedules", "count", len(pipelineSchedules))
+			return nil
+		})
 	}
-
-	var projectVariables ProjectVariables
-	var groupVariables GroupVariables
 	if !skipSet.Has("variables") {
-		groupVariables, err = c.ListGroupVariables(ctx, groups)
-		if err != nil {
-			return nil, fmt.Errorf("listing group variables: %w", err)
-		}
-		slog.Info("fetched group variables", "count", len(groupVariables))
-
-		projectVariables, err = c.ListProjectVariables(ctx, projects)
-		if err != nil {
-			return nil, fmt.Errorf("listing project variables: %w", err)
-		}
-		slog.Info("fetched project variables", "count", len(projectVariables))
+		g.Go(func() error {
+			var err error
+			if groupVariables, err = c.ListGroupVariables(gctx, groups); err != nil {
+				return fmt.Errorf("listing group variables: %w", err)
+			}
+			slog.Info("fetched group variables", "count", len(groupVariables))
+			return nil
+		})
+		g.Go(func() error {
+			var err error
+			if projectVariables, err = c.ListProjectVariables(gctx, projects); err != nil {
+				return fmt.Errorf("listing project variables: %w", err)
+			}
+			slog.Info("fetched project variables", "count", len(projectVariables))
+			return nil
+		})
 	}
-
-	var protectedBranches ProtectedBranches
 	if !skipSet.Has("branch_protection") {
-		protectedBranches, err = c.ListProtectedBranches(ctx, projects)
-		if err != nil {
-			return nil, fmt.Errorf("listing protected branches: %w", err)
-		}
-		slog.Info("fetched protected branches", "count", len(protectedBranches))
+		g.Go(func() error {
+			var err error
+			if protectedBranches, err = c.ListProtectedBranches(gctx, projects); err != nil {
+				return fmt.Errorf("listing protected branches: %w", err)
+			}
+			slog.Info("fetched protected branches", "count", len(protectedBranches))
+			return nil
+		})
 	}
-
-	var protectedTags ProtectedTags
 	if !skipSet.Has("tag_protection") {
-		protectedTags, err = c.ListProtectedTags(ctx, projects)
-		if err != nil {
-			return nil, fmt.Errorf("listing protected tags: %w", err)
-		}
-		slog.Info("fetched protected tags", "count", len(protectedTags))
+		g.Go(func() error {
+			var err error
+			if protectedTags, err = c.ListProtectedTags(gctx, projects); err != nil {
+				return fmt.Errorf("listing protected tags: %w", err)
+			}
+			slog.Info("fetched protected tags", "count", len(protectedTags))
+			return nil
+		})
 	}
-
-	var jobTokenScopes JobTokenScopes
 	if !skipSet.Has("job_token_scopes") {
-		jobTokenScopes, err = c.ListJobTokenScopes(ctx, projects)
-		if err != nil {
-			return nil, fmt.Errorf("listing job token scopes: %w", err)
-		}
-		slog.Info("fetched job token scopes", "count", len(jobTokenScopes))
+		g.Go(func() error {
+			var err error
+			if jobTokenScopes, err = c.ListJobTokenScopes(gctx, projects); err != nil {
+				return fmt.Errorf("listing job token scopes: %w", err)
+			}
+			slog.Info("fetched job token scopes", "count", len(jobTokenScopes))
+			return nil
+		})
+	}
+	if !skipSet.Has("hooks") {
+		g.Go(func() error {
+			var err error
+			if projectHooks, err = c.ListProjectHooks(gctx, projects); err != nil {
+				return fmt.Errorf("listing project hooks: %w", err)
+			}
+			slog.Info("fetched project hooks", "count", len(projectHooks))
+			return nil
+		})
+		g.Go(func() error {
+			var err error
+			if groupHooks, err = c.ListGroupHooks(gctx, groups); err != nil {
+				return fmt.Errorf("listing group hooks: %w", err)
+			}
+			slog.Info("fetched group hooks", "count", len(groupHooks))
+			return nil
+		})
 	}
 
-	var projectHooks ProjectHooks
-	var groupHooks GroupHooks
-	if !skipSet.Has("hooks") {
-		projectHooks, err = c.ListProjectHooks(ctx, projects)
-		if err != nil {
-			return nil, fmt.Errorf("listing project hooks: %w", err)
-		}
-		slog.Info("fetched project hooks", "count", len(projectHooks))
-
-		groupHooks, err = c.ListGroupHooks(ctx, groups)
-		if err != nil {
-			return nil, fmt.Errorf("listing group hooks: %w", err)
-		}
-		slog.Info("fetched group hooks", "count", len(groupHooks))
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	return &Resources{

--- a/internal/gitlab/client_test.go
+++ b/internal/gitlab/client_test.go
@@ -1,0 +1,60 @@
+package gitlab
+
+import (
+	"context"
+	"testing"
+
+	"github.com/xMoelletschi/terraform-gitlab-drift/internal/skip"
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+	gitlabtesting "gitlab.com/gitlab-org/api/client-go/v2/testing"
+	"go.uber.org/mock/gomock"
+)
+
+// FetchAll fetches groups+projects and then the enabled subresource fetchers
+// concurrently. This exercises that the results compose correctly and, under
+// `go test -race`, that the concurrent writes are race-free.
+func TestFetchAll_ComposesResultsConcurrently(t *testing.T) {
+	tc := gitlabtesting.NewTestClient(t)
+	c := NewClientFromAPI(tc.Client, "mygroup")
+
+	mainGroup := &gl.Group{ID: 10, Path: "mygroup", FullPath: "mygroup"}
+	project := &gl.Project{ID: 1, Path: "proj", PathWithNamespace: "mygroup/proj"}
+
+	// Groups + projects (the pre-phase, run concurrently with each other).
+	tc.MockGroups.EXPECT().GetGroup(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(mainGroup, &gl.Response{}, nil)
+	tc.MockGroups.EXPECT().ListDescendantGroups(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, &gl.Response{}, nil)
+	tc.MockGroups.EXPECT().ListGroupProjects(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]*gl.Project{project}, &gl.Response{}, nil)
+
+	// Three subresource fetchers enabled → three concurrent goroutines.
+	tc.MockGroups.EXPECT().ListGroupMembers(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]*gl.GroupMember{{ID: 100, Username: "alice"}}, &gl.Response{}, nil)
+	tc.MockGroupLabels.EXPECT().ListGroupLabels(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]*gl.GroupLabel{{ID: 1, Name: "bug"}}, &gl.Response{}, nil)
+	tc.MockLabels.EXPECT().ListLabels(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]*gl.Label{{ID: 2, Name: "feature", IsProjectLabel: true}}, &gl.Response{}, nil)
+
+	skipSet := skip.Set{
+		"schedules": true, "variables": true, "branch_protection": true,
+		"tag_protection": true, "job_token_scopes": true, "hooks": true,
+	}
+
+	res, err := c.FetchAll(context.Background(), skipSet, FilterConfig{})
+	if err != nil {
+		t.Fatalf("FetchAll error: %v", err)
+	}
+	if len(res.Groups) != 1 || len(res.Projects) != 1 {
+		t.Fatalf("groups=%d projects=%d, want 1 and 1", len(res.Groups), len(res.Projects))
+	}
+	if len(res.GroupMembers[10]) != 1 {
+		t.Errorf("group members not composed: %v", res.GroupMembers)
+	}
+	if len(res.GroupLabels[10]) != 1 {
+		t.Errorf("group labels not composed: %v", res.GroupLabels)
+	}
+	if len(res.ProjectLabels[1]) != 1 {
+		t.Errorf("project labels not composed: %v", res.ProjectLabels)
+	}
+}

--- a/internal/gitlab/concurrency.go
+++ b/internal/gitlab/concurrency.go
@@ -1,0 +1,56 @@
+package gitlab
+
+import (
+	"context"
+	"sync"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+	"golang.org/x/sync/errgroup"
+)
+
+// fetchPerProject fetches a per-project resource concurrently and returns it
+// keyed by project ID. fetch is called once per non-nil project (bounded by
+// concurrency) and returns the value plus whether to keep it — results with
+// keep == false are dropped, matching the per-resource "store only non-empty"
+// convention. The first error cancels the rest and is returned.
+//
+// The client's rate limiter bounds the overall request rate, so this is safe to
+// nest inside FetchAll's fetcher-level concurrency. Use it for any
+// project-scoped fetcher that issues more than one request per project (e.g.
+// job-token scopes, pipeline schedules); single-request fetchers are fine
+// running serially under FetchAll's concurrency.
+func fetchPerProject[R any](
+	ctx context.Context,
+	concurrency int,
+	projects []*gl.Project,
+	fetch func(context.Context, *gl.Project) (R, bool, error),
+) (map[int64]R, error) {
+	result := make(map[int64]R, len(projects))
+	var mu sync.Mutex
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(resolveConcurrency(concurrency))
+
+	for _, p := range projects {
+		if p == nil {
+			continue
+		}
+		g.Go(func() error {
+			val, keep, err := fetch(gctx, p)
+			if err != nil {
+				return err
+			}
+			if keep {
+				mu.Lock()
+				result[p.ID] = val
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/internal/gitlab/concurrency_test.go
+++ b/internal/gitlab/concurrency_test.go
@@ -1,0 +1,46 @@
+package gitlab
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+func TestFetchPerProject(t *testing.T) {
+	projects := []*gl.Project{{ID: 1}, nil, {ID: 2}, {ID: 3}}
+
+	got, err := fetchPerProject(context.Background(), 2, projects,
+		func(_ context.Context, p *gl.Project) (int64, bool, error) {
+			if p.ID == 3 {
+				return 0, false, nil // drop: keep == false
+			}
+			return p.ID * 10, true, nil
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[1] != 10 || got[2] != 20 {
+		t.Fatalf("got %v, want {1:10, 2:20}", got)
+	}
+	if _, ok := got[3]; ok {
+		t.Error("project 3 returned keep=false and must be dropped")
+	}
+	// nil project must be skipped without panicking.
+}
+
+func TestFetchPerProject_PropagatesError(t *testing.T) {
+	projects := []*gl.Project{{ID: 1}, {ID: 2}}
+
+	_, err := fetchPerProject(context.Background(), 2, projects,
+		func(_ context.Context, p *gl.Project) (int64, bool, error) {
+			if p.ID == 2 {
+				return 0, false, errors.New("boom")
+			}
+			return 10, true, nil
+		})
+	if err == nil {
+		t.Error("expected the per-project fetch error to propagate")
+	}
+}

--- a/internal/gitlab/job_token_scopes.go
+++ b/internal/gitlab/job_token_scopes.go
@@ -17,29 +17,22 @@ type JobTokenScope struct {
 type JobTokenScopes = map[int64]*JobTokenScope
 
 func (c *Client) ListJobTokenScopes(ctx context.Context, projects []*gl.Project) (JobTokenScopes, error) {
-	result := make(JobTokenScopes, len(projects))
-
-projectLoop:
-	for _, p := range projects {
-		if p == nil {
-			continue
-		}
+	return fetchPerProject(ctx, c.concurrency, projects, func(ctx context.Context, p *gl.Project) (*JobTokenScope, bool, error) {
 		slog.Debug("fetching job token scopes", "project", p.PathWithNamespace)
 
 		settings, _, err := c.api.JobTokenScope.GetProjectJobTokenAccessSettings(p.ID, gl.WithContext(ctx))
 		if err != nil {
 			if skipInaccessible(err, "job token scopes", p.PathWithNamespace) {
-				continue
+				return nil, false, nil
 			}
-			return nil, fmt.Errorf("getting job token access settings for project %d: %w", p.ID, err)
+			return nil, false, fmt.Errorf("getting job token access settings for project %d: %w", p.ID, err)
 		}
 
 		// The job token scope is a composite resource (settings + both
-		// allowlists). These allowlist fetches deliberately do NOT use the
-		// graceful paginate helper: if an allowlist is inaccessible we skip the
-		// whole project (continue projectLoop) rather than emit a scope with a
-		// misleadingly-empty allowlist, which would read as drift — and on apply
-		// would delete entries we merely could not read.
+		// allowlists). If an allowlist is inaccessible we skip the whole project
+		// (return keep=false) rather than emit a scope with a misleadingly-empty
+		// allowlist, which would read as drift — and on apply would delete
+		// entries we merely could not read.
 		projectOpts := &gl.GetJobTokenInboundAllowListOptions{
 			ListOptions: gl.ListOptions{Page: 1, PerPage: 100},
 		}
@@ -48,9 +41,9 @@ projectLoop:
 			page, resp, err := c.api.JobTokenScope.GetProjectJobTokenInboundAllowList(p.ID, projectOpts, gl.WithContext(ctx))
 			if err != nil {
 				if skipInaccessible(err, "job token inbound allowlist", p.PathWithNamespace) {
-					continue projectLoop
+					return nil, false, nil
 				}
-				return nil, fmt.Errorf("listing job token inbound allowlist projects for project %d: %w", p.ID, err)
+				return nil, false, fmt.Errorf("listing job token inbound allowlist projects for project %d: %w", p.ID, err)
 			}
 			allowedProjects = append(allowedProjects, page...)
 			if resp.NextPage == 0 {
@@ -67,9 +60,9 @@ projectLoop:
 			page, resp, err := c.api.JobTokenScope.GetJobTokenAllowlistGroups(p.ID, groupOpts, gl.WithContext(ctx))
 			if err != nil {
 				if skipInaccessible(err, "job token allowlist groups", p.PathWithNamespace) {
-					continue projectLoop
+					return nil, false, nil
 				}
-				return nil, fmt.Errorf("listing job token allowlist groups for project %d: %w", p.ID, err)
+				return nil, false, fmt.Errorf("listing job token allowlist groups for project %d: %w", p.ID, err)
 			}
 			allowedGroups = append(allowedGroups, page...)
 			if resp.NextPage == 0 {
@@ -123,12 +116,10 @@ projectLoop:
 			allowed = nil
 		}
 
-		result[p.ID] = &JobTokenScope{
+		return &JobTokenScope{
 			InboundEnabled:  settings.InboundEnabled,
 			AllowedProjects: allowed,
 			AllowedGroups:   allowedGroups,
-		}
-	}
-
-	return result, nil
+		}, true, nil
+	})
 }

--- a/internal/gitlab/pipeline_schedules.go
+++ b/internal/gitlab/pipeline_schedules.go
@@ -4,50 +4,66 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
+	"golang.org/x/sync/errgroup"
 )
 
 type PipelineSchedules = map[int64][]*gl.PipelineSchedule
 
 func (c *Client) ListPipelineSchedules(ctx context.Context, projects []*gl.Project) (PipelineSchedules, error) {
 	result := make(PipelineSchedules, len(projects))
+	var mu sync.Mutex
+
+	// Pipeline schedules are the heaviest fetcher: the list endpoint omits
+	// variables, so each schedule needs an extra detail call. To stop this from
+	// becoming the long pole of the scan, fetch projects concurrently. The
+	// client's rate limiter still bounds the overall request rate.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(resolveConcurrency(c.concurrency))
 
 	for _, p := range projects {
 		if p == nil {
 			continue
 		}
-		slog.Debug("fetching pipeline schedules", "project", p.PathWithNamespace)
-		opts := &gl.ListPipelineSchedulesOptions{
-			ListOptions: gl.ListOptions{
-				Page:    1,
-				PerPage: 100,
-			},
-		}
-		schedules, err := paginate(&opts.ListOptions, "pipeline schedules", p.PathWithNamespace, func() ([]*gl.PipelineSchedule, *gl.Response, error) {
-			return c.api.PipelineSchedules.ListPipelineSchedules(p.ID, opts, gl.WithContext(ctx))
-		})
-		if err != nil {
-			return nil, fmt.Errorf("listing pipeline schedules for project %d: %w", p.ID, err)
-		}
-
-		// Fetch detail for each schedule to get variables.
-		var detailed []*gl.PipelineSchedule
-		for _, s := range schedules {
-			slog.Debug("fetching pipeline schedule detail", "project", p.PathWithNamespace, "schedule", s.ID)
-			d, _, err := c.api.PipelineSchedules.GetPipelineSchedule(p.ID, s.ID, gl.WithContext(ctx))
-			if err != nil {
-				if skipInaccessible(err, "pipeline schedule detail", p.PathWithNamespace) {
-					continue
-				}
-				return nil, fmt.Errorf("getting pipeline schedule %d for project %d: %w", s.ID, p.ID, err)
+		g.Go(func() error {
+			slog.Debug("fetching pipeline schedules", "project", p.PathWithNamespace)
+			opts := &gl.ListPipelineSchedulesOptions{
+				ListOptions: gl.ListOptions{Page: 1, PerPage: 100},
 			}
-			detailed = append(detailed, d)
-		}
+			schedules, err := paginate(&opts.ListOptions, "pipeline schedules", p.PathWithNamespace, func() ([]*gl.PipelineSchedule, *gl.Response, error) {
+				return c.api.PipelineSchedules.ListPipelineSchedules(p.ID, opts, gl.WithContext(gctx))
+			})
+			if err != nil {
+				return fmt.Errorf("listing pipeline schedules for project %d: %w", p.ID, err)
+			}
 
-		if len(detailed) > 0 {
-			result[p.ID] = detailed
-		}
+			// Fetch detail for each schedule to get variables.
+			var detailed []*gl.PipelineSchedule
+			for _, s := range schedules {
+				slog.Debug("fetching pipeline schedule detail", "project", p.PathWithNamespace, "schedule", s.ID)
+				d, _, err := c.api.PipelineSchedules.GetPipelineSchedule(p.ID, s.ID, gl.WithContext(gctx))
+				if err != nil {
+					if skipInaccessible(err, "pipeline schedule detail", p.PathWithNamespace) {
+						continue
+					}
+					return fmt.Errorf("getting pipeline schedule %d for project %d: %w", s.ID, p.ID, err)
+				}
+				detailed = append(detailed, d)
+			}
+
+			if len(detailed) > 0 {
+				mu.Lock()
+				result[p.ID] = detailed
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/internal/gitlab/pipeline_schedules.go
+++ b/internal/gitlab/pipeline_schedules.go
@@ -4,66 +4,43 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sync"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
-	"golang.org/x/sync/errgroup"
 )
 
 type PipelineSchedules = map[int64][]*gl.PipelineSchedule
 
+// ListPipelineSchedules is the heaviest fetcher: the list endpoint omits
+// variables, so each schedule needs an extra detail call. fetchPerProject runs
+// the projects concurrently so it doesn't become the scan's long pole; the
+// client's rate limiter still bounds the overall request rate.
 func (c *Client) ListPipelineSchedules(ctx context.Context, projects []*gl.Project) (PipelineSchedules, error) {
-	result := make(PipelineSchedules, len(projects))
-	var mu sync.Mutex
-
-	// Pipeline schedules are the heaviest fetcher: the list endpoint omits
-	// variables, so each schedule needs an extra detail call. To stop this from
-	// becoming the long pole of the scan, fetch projects concurrently. The
-	// client's rate limiter still bounds the overall request rate.
-	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(resolveConcurrency(c.concurrency))
-
-	for _, p := range projects {
-		if p == nil {
-			continue
+	return fetchPerProject(ctx, c.concurrency, projects, func(ctx context.Context, p *gl.Project) ([]*gl.PipelineSchedule, bool, error) {
+		slog.Debug("fetching pipeline schedules", "project", p.PathWithNamespace)
+		opts := &gl.ListPipelineSchedulesOptions{
+			ListOptions: gl.ListOptions{Page: 1, PerPage: 100},
 		}
-		g.Go(func() error {
-			slog.Debug("fetching pipeline schedules", "project", p.PathWithNamespace)
-			opts := &gl.ListPipelineSchedulesOptions{
-				ListOptions: gl.ListOptions{Page: 1, PerPage: 100},
-			}
-			schedules, err := paginate(&opts.ListOptions, "pipeline schedules", p.PathWithNamespace, func() ([]*gl.PipelineSchedule, *gl.Response, error) {
-				return c.api.PipelineSchedules.ListPipelineSchedules(p.ID, opts, gl.WithContext(gctx))
-			})
-			if err != nil {
-				return fmt.Errorf("listing pipeline schedules for project %d: %w", p.ID, err)
-			}
-
-			// Fetch detail for each schedule to get variables.
-			var detailed []*gl.PipelineSchedule
-			for _, s := range schedules {
-				slog.Debug("fetching pipeline schedule detail", "project", p.PathWithNamespace, "schedule", s.ID)
-				d, _, err := c.api.PipelineSchedules.GetPipelineSchedule(p.ID, s.ID, gl.WithContext(gctx))
-				if err != nil {
-					if skipInaccessible(err, "pipeline schedule detail", p.PathWithNamespace) {
-						continue
-					}
-					return fmt.Errorf("getting pipeline schedule %d for project %d: %w", s.ID, p.ID, err)
-				}
-				detailed = append(detailed, d)
-			}
-
-			if len(detailed) > 0 {
-				mu.Lock()
-				result[p.ID] = detailed
-				mu.Unlock()
-			}
-			return nil
+		schedules, err := paginate(&opts.ListOptions, "pipeline schedules", p.PathWithNamespace, func() ([]*gl.PipelineSchedule, *gl.Response, error) {
+			return c.api.PipelineSchedules.ListPipelineSchedules(p.ID, opts, gl.WithContext(ctx))
 		})
-	}
+		if err != nil {
+			return nil, false, fmt.Errorf("listing pipeline schedules for project %d: %w", p.ID, err)
+		}
 
-	if err := g.Wait(); err != nil {
-		return nil, err
-	}
-	return result, nil
+		// Fetch detail for each schedule to get variables.
+		var detailed []*gl.PipelineSchedule
+		for _, s := range schedules {
+			slog.Debug("fetching pipeline schedule detail", "project", p.PathWithNamespace, "schedule", s.ID)
+			d, _, err := c.api.PipelineSchedules.GetPipelineSchedule(p.ID, s.ID, gl.WithContext(ctx))
+			if err != nil {
+				if skipInaccessible(err, "pipeline schedule detail", p.PathWithNamespace) {
+					continue
+				}
+				return nil, false, fmt.Errorf("getting pipeline schedule %d for project %d: %w", s.ID, p.ID, err)
+			}
+			detailed = append(detailed, d)
+		}
+
+		return detailed, len(detailed) > 0, nil
+	})
 }

--- a/internal/gitlab/pipeline_schedules_test.go
+++ b/internal/gitlab/pipeline_schedules_test.go
@@ -1,0 +1,53 @@
+package gitlab
+
+import (
+	"context"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+	gitlabtesting "gitlab.com/gitlab-org/api/client-go/v2/testing"
+	"go.uber.org/mock/gomock"
+)
+
+// ListPipelineSchedules fetches the schedule list per project and then a detail
+// per schedule (the N+1). With multiple projects fetched concurrently this
+// verifies the results compose per project and, under -race, that the
+// concurrent writes are race-free.
+func TestListPipelineSchedules_ComposesPerProject(t *testing.T) {
+	tc := gitlabtesting.NewTestClient(t)
+	c := NewClientFromAPI(tc.Client, "mygroup")
+
+	tc.MockPipelineSchedules.EXPECT().
+		ListPipelineSchedules(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]*gl.PipelineSchedule{{ID: 10, Description: "nightly"}}, &gl.Response{}, nil).
+		Times(2)
+	tc.MockPipelineSchedules.EXPECT().
+		GetPipelineSchedule(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&gl.PipelineSchedule{
+			ID:          10,
+			Description: "nightly",
+			Variables:   []*gl.PipelineVariable{{Key: "K", Value: "V"}},
+		}, &gl.Response{}, nil).
+		Times(2)
+
+	projects := []*gl.Project{
+		{ID: 1, PathWithNamespace: "mygroup/p1"},
+		{ID: 2, PathWithNamespace: "mygroup/p2"},
+	}
+
+	result, err := c.ListPipelineSchedules(context.Background(), projects)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected schedules for 2 projects, got %d", len(result))
+	}
+	for _, id := range []int64{1, 2} {
+		if len(result[id]) != 1 {
+			t.Fatalf("project %d: expected 1 schedule, got %d", id, len(result[id]))
+		}
+		if len(result[id][0].Variables) != 1 {
+			t.Errorf("project %d: schedule detail (variables) not fetched", id)
+		}
+	}
+}

--- a/internal/gitlab/ratelimit.go
+++ b/internal/gitlab/ratelimit.go
@@ -1,0 +1,18 @@
+package gitlab
+
+import "golang.org/x/time/rate"
+
+// newRateLimiter builds a token-bucket limiter from a requests-per-second value,
+// for go-gitlab's WithCustomLimiter. A non-positive value disables limiting
+// (rate.Inf). The burst is ~one second of capacity so concurrent fetchers can
+// proceed up to the configured rate without starving each other.
+func newRateLimiter(reqPerSec float64) *rate.Limiter {
+	if reqPerSec <= 0 {
+		return rate.NewLimiter(rate.Inf, 1)
+	}
+	burst := int(reqPerSec)
+	if burst < 1 {
+		burst = 1
+	}
+	return rate.NewLimiter(rate.Limit(reqPerSec), burst)
+}

--- a/internal/gitlab/ratelimit_test.go
+++ b/internal/gitlab/ratelimit_test.go
@@ -1,0 +1,35 @@
+package gitlab
+
+import (
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+	"golang.org/x/time/rate"
+)
+
+// newRateLimiter must produce a value usable as go-gitlab's RateLimiter.
+var _ gl.RateLimiter = newRateLimiter(1)
+
+func TestNewRateLimiter(t *testing.T) {
+	t.Run("non-positive disables limiting", func(t *testing.T) {
+		if got := newRateLimiter(0).Limit(); got != rate.Inf {
+			t.Errorf("limit = %v, want Inf", got)
+		}
+	})
+
+	t.Run("positive sets rate and burst", func(t *testing.T) {
+		l := newRateLimiter(10)
+		if l.Limit() != rate.Limit(10) {
+			t.Errorf("limit = %v, want 10", l.Limit())
+		}
+		if l.Burst() != 10 {
+			t.Errorf("burst = %d, want 10", l.Burst())
+		}
+	})
+
+	t.Run("fractional rate keeps burst at least 1", func(t *testing.T) {
+		if got := newRateLimiter(0.5).Burst(); got < 1 {
+			t.Errorf("burst = %d, want >= 1", got)
+		}
+	})
+}


### PR DESCRIPTION
## Overview

Phase 3 of the foundation work (on top of the merged #36): make the scan fast on large instances **without risking the GitLab API rate limit**. No new resource types; emitted `.tf` is unchanged.

## What's included

- **Parallel `FetchAll`** — groups+projects fetched concurrently, then the independent subresource fetchers run in a bounded `errgroup` (each writes its own result variable → race-free).
- **Proactive rate limiter** — a token-bucket limiter via go-gitlab's `WithCustomLimiter`, so we stay *under* the API limit rather than relying only on reactive 429 backoff (go-gitlab still retries any stray 429).
- **Reusable `fetchPerProject[R]` helper** — bounded per-project concurrency for heavy fetchers. The two heaviest route through it: `job_token_scopes` (3 calls/project) and `pipeline_schedules` (N+1 detail fetch). Future heavy resources get per-project concurrency in one line.
- **Flags:** `--concurrency` (default 10) and `--rate-limit` (default 10 req/s, `0` = unlimited; conservative for gitlab.com, raise on self-managed instances with headroom).

## Benchmark (gitlab.com, 8 groups / 61 projects, `--skip premium`)

| Build | Wall-clock |
|---|---|
| v1.13.0 (release, serial) | ~144 s |
| this branch (parallel) | **~70 s (~2×)** |

Rate-bound at the safe 10 req/s default, **no 429s**. The 2× is the rate ceiling vs serial's latency-bound throughput; raising `--rate-limit` goes further where the instance allows it.

## Safety

The rate limiter caps total requests regardless of goroutine count (including the nested per-project concurrency in `fetchPerProject`), so concurrency never risks tripping the limit.

## Verification

`go build -race`, `go vet`, `go test -race ./...`, `golangci-lint` — all green (0 lint issues). New tests run under `-race`: `fetchPerProject`, `FetchAll` composition, `ListPipelineSchedules` multi-project, plus the rate-limiter and existing fetcher tests.